### PR TITLE
Fix occasionally defective date when using allday

### DIFF
--- a/js/app/services/businesslayer/tasksbusinesslayer.js
+++ b/js/app/services/businesslayer/tasksbusinesslayer.js
@@ -140,6 +140,14 @@ angular.module('Tasks').factory('TasksBusinessLayer', [
 				});
 			};
 
+			TasksBusinessLayer.prototype.momentToICALTime = function(moment, asDate) {
+				if(asDate) {
+					return ICAL.Time.fromDateString(moment.format('YYYY-MM-DD'));
+				} else {
+					return ICAL.Time.fromDateTimeString(moment.format('YYYY-MM-DDTHH:mm:ss'));
+				}
+			};
+
 			TasksBusinessLayer.prototype.initDueDate = function(task) {
 				var due = moment(task.due, "YYYY-MM-DDTHH:mm:ss");
 				if (!due.isValid()) {
@@ -170,8 +178,7 @@ angular.module('Tasks').factory('TasksBusinessLayer', [
 				} else {
 					return;
 				}
-				task.due = due.format('YYYY-MM-DDTHH:mm:ss');
-				task.due.isDate = allDay;
+				task.due = this.momentToICALTime(due, allDay);
 				// this.checkReminderDate(task);
 				this.doUpdate(task);
 			};
@@ -213,8 +220,7 @@ angular.module('Tasks').factory('TasksBusinessLayer', [
 				} else {
 					return;
 				}
-				task.start = start.format('YYYY-MM-DDTHH:mm:ss');
-				task.start.isDate = allDay;
+				task.start = this.momentToICALTime(start, allDay);
 				// this.checkReminderDate(taskID);
 				this.doUpdate(task);
 			};

--- a/js/public/app.js
+++ b/js/public/app.js
@@ -2169,6 +2169,14 @@ angular.module('Tasks').factory('TasksBusinessLayer', [
 				});
 			};
 
+			TasksBusinessLayer.prototype.momentToICALTime = function(moment, asDate) {
+				if(asDate) {
+					return ICAL.Time.fromDateString(moment.format('YYYY-MM-DD'));
+				} else {
+					return ICAL.Time.fromDateTimeString(moment.format('YYYY-MM-DDTHH:mm:ss'));
+				}
+			};
+
 			TasksBusinessLayer.prototype.initDueDate = function(task) {
 				var due = moment(task.due, "YYYY-MM-DDTHH:mm:ss");
 				if (!due.isValid()) {
@@ -2199,8 +2207,7 @@ angular.module('Tasks').factory('TasksBusinessLayer', [
 				} else {
 					return;
 				}
-				task.due = due.format('YYYY-MM-DDTHH:mm:ss');
-				task.due.isDate = allDay;
+				task.due = this.momentToICALTime(due, allDay);
 				// this.checkReminderDate(task);
 				this.doUpdate(task);
 			};
@@ -2242,8 +2249,7 @@ angular.module('Tasks').factory('TasksBusinessLayer', [
 				} else {
 					return;
 				}
-				task.start = start.format('YYYY-MM-DDTHH:mm:ss');
-				task.start.isDate = allDay;
+				task.start = this.momentToICALTime(start, allDay);
 				// this.checkReminderDate(taskID);
 				this.doUpdate(task);
 			};


### PR DESCRIPTION
When using the new all-day feature (#3), sometimes the saved date was defective. Then, the frontend looks correct, but in the backend iCal entry, the date was saved in the format "YYYY-MM-" instead of "YYYYMMDD". After refreshing the tasks app, a wrong date was shown.

I've fixed this bug by introducing a new helper method `momentToICALTime` which uses the respective `ical.js` functions in order to create a `date` or `datetime`.