### PR TITLE
Ensure that START < DUE if both set

### DIFF
--- a/js/app/services/businesslayer/tasksbusinesslayer.js
+++ b/js/app/services/businesslayer/tasksbusinesslayer.js
@@ -209,8 +209,10 @@ angular.module('Tasks').factory('TasksBusinessLayer', [
 				var start = moment(task.start, "YYYY-MM-DDTHH:mm:ss");
 				var due = moment(task.due, "YYYY-MM-DDTHH:mm:ss");
 				if (!start.isValid()) {
-					var reference = due.isBefore() ? due : moment();
-					reference.subtract(1, 'm');
+					var reference = moment().add(1, 'h');
+					if (due.isBefore(reference)) {
+						reference = due.subtract(1, 'm');
+					}
 					reference.startOf(task.allDay ? 'day' : 'hour');
 					return this.setStart(task, reference, 'all');
 				}
@@ -271,7 +273,7 @@ angular.module('Tasks').factory('TasksBusinessLayer', [
 				}
  				this.doUpdate(task);
  			};
- 
+
 			TasksBusinessLayer.prototype.initReminder = function(taskID) {
 				var p, task;
 				if (!this.checkReminderDate(taskID)) {

--- a/js/app/services/businesslayer/tasksbusinesslayer.js
+++ b/js/app/services/businesslayer/tasksbusinesslayer.js
@@ -149,9 +149,16 @@ angular.module('Tasks').factory('TasksBusinessLayer', [
 			};
 
 			TasksBusinessLayer.prototype.initDueDate = function(task) {
+				var start = moment(task.start, "YYYY-MM-DDTHH:mm:ss");
 				var due = moment(task.due, "YYYY-MM-DDTHH:mm:ss");
 				if (!due.isValid()) {
-					return this.setDue(task, moment().startOf('hour').add(1, 'h'), 'time');
+					var reference = start.isAfter() ? start : moment();
+					if(task.allDay) {
+						reference.startOf('day').add(1, 'd');
+					} else {
+						reference.startOf('hour').add(1, 'h');
+					}
+					return this.setDue(task, reference, 'all');
 				}
 			};
 
@@ -160,7 +167,9 @@ angular.module('Tasks').factory('TasksBusinessLayer', [
 					type = 'day';
 				}
 				var allDay = task.allDay;
-				var due = moment(task.due, "YYYY-MM-DDTHH:mm:ss");
+				var start = moment(task.start, "YYYY-MM-DDTHH:mm:ss");
+				var olddue = moment(task.due, "YYYY-MM-DDTHH:mm:ss");
+				var due = olddue.clone();
 				if (type === 'day') {
 					if (moment(due).isValid()) {
 						due.year(date.year()).month(date.month()).date(date.date());
@@ -178,6 +187,10 @@ angular.module('Tasks').factory('TasksBusinessLayer', [
 				} else {
 					return;
 				}
+				if(due.isBefore(start) || due.isSame(start)) {
+					start.subtract(olddue.diff(due), 'ms');
+					task.start = this.momentToICALTime(start, allDay);
+				}
 				task.due = this.momentToICALTime(due, allDay);
 				// this.checkReminderDate(task);
 				this.doUpdate(task);
@@ -194,8 +207,12 @@ angular.module('Tasks').factory('TasksBusinessLayer', [
 
 			TasksBusinessLayer.prototype.initStartDate = function(task) {
 				var start = moment(task.start, "YYYY-MM-DDTHH:mm:ss");
+				var due = moment(task.due, "YYYY-MM-DDTHH:mm:ss");
 				if (!start.isValid()) {
-					return this.setStart(task, moment().startOf('hour').add(1, 'h'), 'time');
+					var reference = due.isBefore() ? due : moment();
+					reference.subtract(1, 'm');
+					reference.startOf(task.allDay ? 'day' : 'hour');
+					return this.setStart(task, reference, 'all');
 				}
 			};
 
@@ -204,7 +221,9 @@ angular.module('Tasks').factory('TasksBusinessLayer', [
 					type = 'day';
 				}
 				var allDay = task.allDay;
-				var start = moment(task.start, "YYYY-MM-DDTHH:mm:ss");
+				var due = moment(task.due, "YYYY-MM-DDTHH:mm:ss");
+				var oldstart = moment(task.start, "YYYY-MM-DDTHH:mm:ss");
+				var start = oldstart.clone();
 				if (type === 'day') {
 					if (moment(start).isValid()) {
 						start.year(date.year()).month(date.month()).date(date.date());
@@ -217,8 +236,14 @@ angular.module('Tasks').factory('TasksBusinessLayer', [
 					} else {
 						start = date;
 					}
+				} else if (type === 'all') {
+					start = date;
 				} else {
 					return;
+				}
+				if(start.isAfter(due) || start.isSame(due)) {
+					due.add(start.diff(oldstart), 'ms');
+					task.due = this.momentToICALTime(due, allDay);
 				}
 				task.start = this.momentToICALTime(start, allDay);
 				// this.checkReminderDate(taskID);
@@ -236,6 +261,14 @@ angular.module('Tasks').factory('TasksBusinessLayer', [
 
  			TasksBusinessLayer.prototype.setAllDay = function(task, allDay) {
  				task.allDay = allDay;
+				if(allDay) {
+					var due = moment(task.due, "YYYY-MM-DDTHH:mm:ss");
+					var start = moment(task.start, "YYYY-MM-DDTHH:mm:ss");
+					if(start.isAfter(due) || start.isSame(due)) {
+						start = moment(due).subtract(1, 'day');
+						task.start = this.momentToICALTime(start, allDay);
+					}
+				}
  				this.doUpdate(task);
  			};
  

--- a/js/public/app.js
+++ b/js/public/app.js
@@ -2238,8 +2238,10 @@ angular.module('Tasks').factory('TasksBusinessLayer', [
 				var start = moment(task.start, "YYYY-MM-DDTHH:mm:ss");
 				var due = moment(task.due, "YYYY-MM-DDTHH:mm:ss");
 				if (!start.isValid()) {
-					var reference = due.isBefore() ? due : moment();
-					reference.subtract(1, 'm');
+					var reference = moment().add(1, 'h');
+					if (due.isBefore(reference)) {
+						reference = due.subtract(1, 'm');
+					}
 					reference.startOf(task.allDay ? 'day' : 'hour');
 					return this.setStart(task, reference, 'all');
 				}
@@ -2300,7 +2302,7 @@ angular.module('Tasks').factory('TasksBusinessLayer', [
 				}
  				this.doUpdate(task);
  			};
- 
+
 			TasksBusinessLayer.prototype.initReminder = function(taskID) {
 				var p, task;
 				if (!this.checkReminderDate(taskID)) {


### PR DESCRIPTION
Fixes owncloud/tasks#351: The standard forbids that START>DUE, so these changes have the purpose to be conform to the respective [RFC 5545](https://tools.ietf.org/html/rfc5545#section-3.8.2.3).

- [x] default values for `START` and `DUE` (i.e. if the field was unset before and should now be set) are calculated from `DUE` (if `START` should be set and `DUE` is set and is in the past) resp. `START` (if `DUE` should be set and `START` is set and is in the future) instead from the current time.
- [x] default value for `START` is now rounded downwards (instead of upwards) in order to calculate a value with `START<DUE`
- [x] if `START` or `DUE` is changed so that `START>DUE` would be true, the other value (`DUE`/`START`) will be changed, so that the time between `START` and `DUE` will remain like before the change. Therefore, if `START<=DUE` before changing the task, then `START<=DUE` afterwards.
- [x] disallow `START=DUE`, see the discussion under owncloud/tasks#351