### PR TITLE
renamed and and updated links from ownCloud to Nextcloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # Tasks
 
-[![Build Status](https://scrutinizer-ci.com/g/owncloud/tasks/badges/build.png?b=master)](https://scrutinizer-ci.com/g/owncloud/tasks/build-status/master) [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/owncloud/tasks/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/owncloud/tasks/?branch=master) [![Code Coverage](https://scrutinizer-ci.com/g/owncloud/tasks/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/owncloud/tasks/?branch=master)
+[![Build Status](https://scrutinizer-ci.com/g/nextcloud/tasks/badges/build.png?b=master)](https://scrutinizer-ci.com/g/nextcloud/tasks/build-status/master) [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/nextcloud/tasks/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/nextcloud/tasks/?branch=master) [![Code Coverage](https://scrutinizer-ci.com/g/nextcloud/tasks/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/nextcloud/tasks/?branch=master)
 
-Tasks app for ownCloud.
+Tasks app for Nextcloud.
 
 ### Installation
 
- * **Using git:** In your `owncloud/apps/` directory, run `git clone https://github.com/owncloud/tasks/`. Then go to the Apps manager tab in your Owncloud web interface, and enable the Tasks app.
- * **Using the zip archive:** Download the latest [zip archive](https://github.com/owncloud/tasks/archive/master.zip), extract the `tasks-master` directory inside your `owncloud/apps/` directory, and rename it to `tasks`. For stable releases, you can also download one of the [releases](https://github.com/owncloud/tasks/releases) tar.gz archives. Then go to the Apps manager tab in your Owncloud web interface, and enable the Tasks app.
+ * **Using git:** In your `nextcloud/apps/` directory, run `git clone https://github.com/nextcloud/tasks/`. Then go to the Apps manager tab in your Nextcloud web interface, and enable the Tasks app.
+ * **Using the zip archive:** Download the latest [zip archive](https://github.com/nextcloud/tasks/archive/master.zip), extract the `tasks-master` directory inside your `nextcloud/apps/` directory, and rename it to `tasks`. For stable releases, you can also download one of the [releases](https://github.com/nextcloud/tasks/releases) tar.gz archives. Then go to the Apps manager tab in your Nextcloud web interface, and enable the Tasks app.
  
 ### Usage/Features
 
-Once enabled, a new `Tasks` menu will appear in your owncloud apps menu. From there you can **add and delete tasks, edit their title, description,  start and due dates, reminder times, mark them as important, and add comments on them**. Tasks can be **shared** between users. Tasks can be **synchronized using CalDav** (each task list is linked to an Owncloud calendar, to sync it to your local client - Thunderbird, Evolution, KDE Kontact, iCal... - just add the calendar as a remote calendar in you client). You can **download your tasks as ICS** files using the download button for each calendar.
+Once enabled, a new `Tasks` menu will appear in your Nextcloud apps menu. From there you can **add and delete tasks, edit their title, description,  start and due dates, reminder times, mark them as important, and add comments on them**. Tasks can be **shared** between users. Tasks can be **synchronized using CalDav** (each task list is linked to an Nextcloud calendar, to sync it to your local client - Thunderbird, Evolution, KDE Kontact, iCal... - just add the calendar as a remote calendar in you client). You can **download your tasks as ICS** files using the download button for each calendar.
 
 ### Screenshot
 


### PR DESCRIPTION
The description (and the download links!) in README.md still stated ownCloud and pointed to ownCloud repositories.