### PR TITLE
Fix slider when narrow and adjustment for nc12

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -934,12 +934,13 @@
 #app-sidebar div.content-wrapper .body .section input[type="range"] {
   border: medium none;
   box-shadow: none;
-  width: 190px;
-  margin: 5px 36px 0 0;
+  width: calc(100% - 90px);
+  margin: 5px 36px 0 5px;
   height: 17px;
 }
 #app-sidebar div.content-wrapper .body .section input[type="text"] {
   float: left;
+  min-height: 0;
 }
 #app-sidebar div.content-wrapper .body .section .select2-search-field input {
   border: 0 none;


### PR DESCRIPTION
Fixes #68. Also input was too large for the row since nc12 introduced `min-height: 32px;` on all inputs.

Before: 
![localhost-index php-apps-tasks- nexus 5x 1](https://cloud.githubusercontent.com/assets/1389813/25780714/1043a874-332d-11e7-86bf-b4665960d774.png)
After:
![localhost-index php-apps-tasks- nexus 5x 2](https://cloud.githubusercontent.com/assets/1389813/25780717/1450e404-332d-11e7-97eb-a1c9f08295c2.png)
