### PR TITLE
Fix icon opacities

### DIFF
--- a/css/src/style.scss
+++ b/css/src/style.scss
@@ -513,10 +513,6 @@ ol[dnd-list] {
 		}
 	}
 
-	.task-star .icon:hover {
-		opacity: .7;
-	}
-
 	.subtasks-container {
 		margin-left: 35px;
 
@@ -697,10 +693,6 @@ ol[dnd-list] {
 			a {
 				padding: 7px;
 
-				&:hover .icon {
-					opacity: 1;
-				}
-
 				&.left {
 					float: left;
 				}
@@ -791,10 +783,6 @@ ol[dnd-list] {
 					height: 24px;
 					width: 24px;
 					background-size: 144px 144px;
-
-					&:hover {
-						opacity: 1;
-					}
 				}
 			}
 
@@ -879,6 +867,13 @@ ol[dnd-list] {
 				&.detail-note {
 					padding: 20px 0;
 					height: auto;
+				}
+
+				&.detail-all-day {
+					div,
+					span {
+						cursor: pointer;
+					}
 				}
 
 				&.editing {
@@ -1169,6 +1164,22 @@ ol[dnd-list] {
 	cursor: not-allowed;
 }
 
+.reactive {
+	&:hover {
+		.icon {
+			opacity: .7;
+		}
+
+		.detail-checkbox:not(.disabled) {
+			border-color: $black;
+		}
+	}
+
+	.icon {
+		cursor: pointer;
+	}
+}
+
 .icon {
 	height: 16px;
 	width: 16px;
@@ -1176,6 +1187,19 @@ ol[dnd-list] {
 	vertical-align: middle;
 	opacity: .5;
 	transition: opacity 100ms ease 0s;
+	cursor: default;
+
+	&.reactive {
+		cursor: pointer;
+
+		&:hover {
+			opacity: .7;
+		}
+	}
+
+	&.active {
+		opacity: .7;
+	}
 
 	&.icon-checkmark,
 	&.icon-tag-active,
@@ -1209,15 +1233,6 @@ ol[dnd-list] {
 
 	&.right {
 		float: right;
-	}
-
-	&.toggle-completed-subtasks {
-		float: right;
-		opacity: 1;
-
-		&:hover {
-			opacity: 1;
-		}
 	}
 }
 

--- a/templates/main.php
+++ b/templates/main.php
@@ -23,7 +23,7 @@
     <div id="app-navigation" ng-controller="ListController">
         <ul id="collections">
             <li id="collection_{{ collection.id }}"
-                class="collection"
+                class="collection reactive"
                 collectionID="{{collection.id}}"
                 ng-repeat="collection in collections"
                 ng-class="{'animate-up': hideCollection(collection.id), active: collection.id==route.collectionID}"
@@ -121,7 +121,7 @@
                     </form>
                 </div>
             </li>
-            <li class="newList handler" ng-class="{edit: status.addingList}">
+            <li class="newList handler reactive" ng-class="{edit: status.addingList}">
                 <a class="addlist"
                     ng-click="startCreate()"
                     oc-click-focus="{selector: '#newList', timeout: 0}">

--- a/templates/part.details.php
+++ b/templates/part.details.php
@@ -5,14 +5,14 @@
         ng-show="TaskState()=='found'"
         ng-class="{'disabled': !task.calendar.writable}">
     	<div class="title" ng-class="{'editing':route.parameter=='name'}">
-            <a class="checkbox"
+            <a class="checkbox reactive"
                 ng-click="toggleCompleted(task)"
                 role="checkbox"
                 aria-checked="{{task.completed}}"
                 aria-label="<?php p($l->t('Task is completed')); ?>">
             	<span class="icon detail-checkbox" ng-class="{'icon-checkmark':task.completed, 'disabled': !task.calendar.writable}"></span>
             </a>
-            <a class="star" ng-click="toggleStarred(task)">
+            <a class="star reactive" ng-click="toggleStarred(task)">
             	<span class="icon icon-task-star"
                     ng-class="{'icon-task-star-high':task.priority>5,'icon-task-star-medium':task.priority==5,'icon-task-star-low':task.priority > 0 && task.priority < 5, 'disabled': !task.calendar.writable}"></span>
             </a>
@@ -63,10 +63,10 @@
                    </div>
                    <div class="utils">
                         <a>
-                            <span class="icon detail-save icon-checkmark-color handler end-edit"></span>
+                            <span class="icon detail-save icon-checkmark-color handler end-edit reactive"></span>
                         </a>
                         <a class="handler end-edit" ng-click="deleteStartDate(task)">
-                            <span class="icon icon-trash"></span>
+                            <span class="icon icon-trash reactive"></span>
                         </a>
                     </div>
                 </li>
@@ -96,14 +96,14 @@
                     </div>
                     <div class="utils">
                         <a>
-                            <span class="icon detail-save icon-checkmark-color handler end-edit"></span>
+                            <span class="icon detail-save icon-checkmark-color handler end-edit reactive"></span>
                         </a>
                         <a class="handler end-edit" ng-click="deleteDueDate(task)">
-                            <span class="icon icon-trash"></span>
+                            <span class="icon icon-trash reactive"></span>
                         </a>
                     </div>
                 </li>
-                <li class="section detail-all-day handler"
+                <li class="section detail-all-day handler reactive"
                     ng-click="toggleAllDay(task)"
                     ng-if="isAllDayPossible(task)"
                     role="checkbox"
@@ -139,10 +139,10 @@
                     </div>
                     <div class="utils">
                         <a>
-                            <span class="icon detail-save icon-checkmark-color handler end-edit"></span>
+                            <span class="icon detail-save icon-checkmark-color handler end-edit reactive"></span>
                         </a>
                         <a class="handler end-edit" ng-click="deletePriority(task)">
-                            <span class="icon icon-trash"></span>
+                            <span class="icon icon-trash reactive"></span>
                         </a>
                 </li>
                 <li class="section detail-complete handler"
@@ -168,10 +168,10 @@
                     </div>
                     <div class="utils">
                         <a>
-                            <span class="icon detail-save icon-checkmark-color handler end-edit"></span>
+                            <span class="icon detail-save icon-checkmark-color handler end-edit reactive"></span>
                         </a>
                         <a class="handler end-edit" ng-click="deletePercent(task)">
-                            <span class="icon icon-trash"></span>
+                            <span class="icon icon-trash reactive"></span>
                         </a>
                     </div>
                 </li>
@@ -218,12 +218,12 @@
             </ul>
         </div>
         <div class="footer">
-        	<a class="handler left close-all"
+        	<a class="handler left close-all reactive"
                 ng-click="deleteTask(task)"
                 ng-show="task.calendar.writable">
             	<span class="icon icon-trash"></span>
             </a>
-            <a class="handler right close-all">
+            <a class="handler right close-all reactive">
             	<span class="icon icon-hide"></span>
             </a>
         </div>

--- a/templates/part.taskbody.php
+++ b/templates/part.taskbody.php
@@ -16,28 +16,28 @@
         role="checkbox"
         aria-checked="{{task.completed}}"
         aria-label="<?php p($l->t('Task is completed')); ?>">
-        <span class="icon task-checkbox" ng-class="{'icon-checkmark': task.completed}"></span>
+        <span class="icon task-checkbox reactive" ng-class="{'icon-checkmark': task.completed}"></span>
     </a>
     <a class="icon task-separator"></a>
     <a class="task-star handler" ng-click="toggleStarred(task)">
-        <span class="icon icon-task-star right large"ng-class="{'icon-task-star-high':task.priority > 5, 'icon-task-star-medium':task.priority == 5, 'icon-task-star-low':task.priority > 0 && task.priority < 5}">
+        <span class="icon icon-task-star right large reactive"ng-class="{'icon-task-star-high':task.priority > 5, 'icon-task-star-medium':task.priority == 5, 'icon-task-star-low':task.priority > 0 && task.priority < 5}">
         </span>
     </a>
     <a class="task-addsubtask handler add-subtask"
         ng-show="task.calendar.writable"
         ng-click="showSubtaskInput(task.uid)"
         oc-click-focus="{selector: '.add-subtask input', timeout: 0}">
-        <span class="icon icon-add right large" title="<?php p($l->t('add a subtask to')); ?> {{ task.summary }}"></span>
+        <span class="icon icon-add right large reactive" title="<?php p($l->t('add a subtask to')); ?> {{ task.summary }}"></span>
     </a>
-    <a class="handler"  ng-click="toggleSubtasks(task)">
-        <span class="icon right large subtasks"
+    <a class="handler" ng-click="toggleSubtasks(task)">
+        <span class="icon right large subtasks reactive"
             ng-class="task.hideSubtasks ? 'icon-subtasks-hidden' : 'icon-subtasks-visible'"
             title="<?php p($l->t('Toggle subtasks')); ?>">
         </span>
     </a>
-    <a class="handler"  ng-click="toggleCompletedSubtasks(task)">
-        <span class="icon icon-toggle right large toggle-completed-subtasks"
-            ng-class="{'hidden': task.hideCompletedSubtasks}"
+    <a class="handler" ng-click="toggleCompletedSubtasks(task)">
+        <span class="icon icon-toggle right large toggle-completed-subtasks reactive"
+            ng-class="{'active': !task.hideCompletedSubtasks}"
             title="<?php p($l->t('Toggle completed subtasks')); ?>">
         </span>
     </a>


### PR DESCRIPTION
This PR fixes the opacities of several icons when hovered or active.

For icons which are interactive, opacity changes to 0.7 now when hovered (e.g. adding a subtask or starring a task). Other icons which only indicate something but cannot be clicked have no hover effect (e.g. the icon indicating whether or not a task has a note).

Also the icon showing if completed subtasks should be shown (the eye) now has a opacity of 0.7 when the tasks are shown.