### PR TITLE
Set min-version to 13

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -22,6 +22,6 @@
     <repository type="git">https://github.com/nextcloud/tasks.git</repository>
     <dependencies>
         <owncloud min-version="0" max-version="0"/>
-        <nextcloud min-version="14" max-version="14"/>
+        <nextcloud min-version="13" max-version="14"/>
     </dependencies>
 </info>


### PR DESCRIPTION
I tested current master on NC13 now and it seems to work fine. So set min-versoin to 13 to support this too.