### PR TITLE
Adjust confirmation tooltip visibility and message, closes #196

### DIFF
--- a/js/app/controllers/listcontroller.js
+++ b/js/app/controllers/listcontroller.js
@@ -50,7 +50,7 @@ angular.module('Tasks').controller('ListController', [
 				this._$scope.color = '#31CC7C';
 
 				this._$scope.deleteMessage = function (calendar) {
-					return t('tasks', 'This will delete the Calendar "%s" and all of its entries.').replace('%s', calendar.displayname);
+					return t('tasks', 'This will delete the calendar "%s" and all corresponding events and tasks.').replace('%s', calendar.displayname);
 				};
 
 				this._$scope["delete"] = function(calendar) {

--- a/js/app/directives/confirmation.js
+++ b/js/app/directives/confirmation.js
@@ -51,8 +51,7 @@ angular.module('Tasks').controller('ConfirmationController', [
 					}
 					e.stopPropagation();
 					_$scope.activate();
-					$element.children('.confirmation-confirm')
-					.tooltip({title: message, container: 'body', placement: 'right'});
+					$element.tooltip({title: message, container: 'body', placement: 'right', trigger: 'manual'}).tooltip('show');
 					$element.addClass("confirmed");
 				});
 
@@ -67,6 +66,7 @@ angular.module('Tasks').controller('ConfirmationController', [
 
 				this._$scope.documentClick = function () {
 					$element.removeClass("confirmed");
+					$element.tooltip('hide');
 				};
 
 				this._$scope.activate = function () {


### PR DESCRIPTION
Confirmation tooltip is now permanently shown after clicking on delete, the message now reads `This will delete the calendar "xyz" and all corresponding events and tasks.`