### PR TITLE
Do not overwrite class attribute of content node

### DIFF
--- a/js/app/app.js
+++ b/js/app/app.js
@@ -23,7 +23,7 @@ $('#content.app-tasks').attr('ng-app', 'Tasks');
 $('#content.app-tasks').attr('ng-cloak');
 $('#content.app-tasks').attr('ng-controller', 'AppController');
 $('#content.app-tasks').attr('ng-click', 'closeAll($event)');
-$('#content.app-tasks').attr('class', 'handler');
+$('#content.app-tasks').addClass('handler');
 
 angular.module('Tasks', ['ngRoute', 'ngAnimate', 'ui.select', 'ngSanitize', 'dndLists']).config([
 	'$provide', '$routeProvider', '$interpolateProvider', '$httpProvider',


### PR DESCRIPTION
I noticed that content node of the Tasks app was missing the `app-<app_id>` class, because the nextcloud [theme](https://github.com/mwalbeck/nextcloud-breeze-dark) I am using broke.