### PR TITLE
Implement drag and drop

### DIFF
--- a/css/src/style.scss
+++ b/css/src/style.scss
@@ -451,6 +451,14 @@
 		}
 	}
 
+	&.sortable-ghost .task-body {
+		background-color: rgba( $color-primary, .3 );
+	}
+
+	&.dragover > div.subtasks-container > ol {
+		min-height: 37px;
+	}
+
 	.subtasks-container {
 		margin-left: 35px;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13482,6 +13482,11 @@
         "kind-of": "^3.2.0"
       }
     },
+    "sortablejs": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.8.4.tgz",
+      "integrity": "sha512-Brqnzelu1AhFuc0Fn3N/qFex1tlIiuQIUsfu2J8luJ4cRgXYkWrByxa+y5mWEBlj8A0YoABukflIJwvHyrwJ6Q=="
+    },
     "source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -15705,6 +15710,14 @@
       "integrity": "sha512-EW8M4PPDJG2c2cZXZCYLVregx4dhlJ+GC7rDGuGex0MlnhM8SHegL+/xFxrnUBD9NLvwrgWEEub5i7Ic/EG/+w==",
       "requires": {
         "fecha": "^2.3.3"
+      }
+    },
+    "vuedraggable": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-2.20.0.tgz",
+      "integrity": "sha512-mrSWGkzY40nkgLDuuoxrs6/0u+A7VwXtQRruLQYOVjwd8HcT3BZatRvzw4qVCwJczsAYPbaMubkGOEtzDOzhsQ==",
+      "requires": {
+        "sortablejs": "^1.8.4"
       }
     },
     "vuex": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 		"vue": "^2.6.10",
 		"vue-clipboard2": "^0.3.0",
 		"vue-router": "3.0.6",
+		"vuedraggable": "^2.20.0",
 		"vuex": "^3.1.0",
 		"vuex-router-sync": "^5.0.0"
 	},

--- a/src/components/Task.vue
+++ b/src/components/Task.vue
@@ -113,13 +113,16 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 					>
 				</form>
 			</div>
-			<ol v-if="!task.hideSubtasks || searchQuery" :calendarID="task.calendar.uri">
+			<task-drag-container v-if="!task.hideSubtasks || searchQuery"
+				:task-id="task.uri"
+				:calendar-id="task.calendar.uri"
+			>
 				<TaskBodyComponent v-for="subtask in filteredSubtasks"
 					:key="subtask.uid"
 					:task="subtask"
 					class="subtask"
 				/>
-			</ol>
+			</task-drag-container>
 		</div>
 	</li>
 </template>
@@ -131,6 +134,7 @@ import { mapGetters, mapActions } from 'vuex'
 import focus from '../directives/focus'
 import { linkify } from '../directives/linkify.js'
 import TaskStatusDisplay from './TaskStatusDisplay'
+import TaskDragContainer from './TaskDragContainer'
 
 export default {
 	name: 'TaskBodyComponent',
@@ -141,6 +145,7 @@ export default {
 	},
 	components: {
 		TaskStatusDisplay,
+		TaskDragContainer,
 	},
 	filters: {
 		formatDate: function(date) {
@@ -311,7 +316,7 @@ export default {
 
 			this.createTask(task)
 			this.newTaskName = ''
-		}
+		},
 	}
 }
 </script>

--- a/src/components/TaskDragContainer.vue
+++ b/src/components/TaskDragContainer.vue
@@ -1,0 +1,133 @@
+<!--
+Nextcloud - Tasks
+
+@author Raimund Schlüßler
+@copyright 2018 Raimund Schlüßler <raimund.schluessler@mailbox.org>
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+License as published by the Free Software Foundation; either
+version 3 of the License, or any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+
+You should have received a copy of the GNU Affero General Public
+License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+
+<template>
+	<draggable tag="ol"
+		:list="['']"
+		v-bind="{group: 'tasks', swapThreshold: 0.30}"
+		:move="onMove"
+		@end="onEnd"
+	>
+		<slot :move="onMove" />
+	</draggable>
+</template>
+
+<script>
+import draggable from 'vuedraggable'
+import { mapGetters, mapActions } from 'vuex'
+
+export default {
+	components: {
+		draggable,
+	},
+	computed: {
+		...mapGetters({
+			getCalendar: 'getCalendarById',
+			getTask: 'getTaskByUri',
+		}),
+	},
+	methods: {
+		...mapActions([
+			'moveTask',
+		]),
+
+		/**
+		 * Called when a task is dragged.
+		 *
+		 * @param {Object} $event The event which caused the move
+		 */
+		onMove: function($event) {
+			this.cleanUpDragging()
+			$event.related.classList.add('dragover')
+		},
+
+		/**
+		 * Called when a task is dropped.
+		 *
+		 * @param {Object} $event The event which caused the drop
+		 */
+		onEnd: function($event) {
+			// Move the task to a new calendar or parent.
+			this.prepareMoving($event)
+			this.prepareCollecting($event)
+			this.cleanUpDragging()
+			$event.stopPropagation()
+		},
+
+		/**
+		 * Called when we stopped dragging. Cleans up temporarily added classes.
+		 */
+		cleanUpDragging: function() {
+			var items = document.getElementsByClassName('task-item')
+			for (let i = 0; i < items.length; i++) {
+				items[i].classList.remove('dragover')
+			}
+		},
+
+		/**
+		 * Function to move a task to a new calendar or parent
+		 *
+		 * @param {Object} $event The event which caused the move
+		 */
+		prepareMoving: function($event) {
+			var task, parent, calendar
+			// The task to move
+			var taskAttribute = $event.item.attributes['task-id']
+			if (taskAttribute) {
+				task = this.getTask(taskAttribute.value)
+			}
+			// The new calendar --> make the moved task a root task
+			var calendarAttribute = $event.to.attributes['calendar-id']
+			if (calendarAttribute) {
+				calendar = this.getCalendar(calendarAttribute.value)
+			}
+			// The new parent task --> make the moved task a subtask
+			var parentAttribute = $event.to.attributes['task-id']
+			if (parentAttribute) {
+				parent = this.getTask(parentAttribute.value)
+				// If we move to a parent task, the calendar has to be the parents calendar.
+				calendar = parent.calendar
+			}
+			// If no calendar is given (e.g. in week collection), the calendar is unchanged.
+			if (!calendar) {
+				calendar = task.calendar
+			}
+			// Move the task to the appropriate calendar and parent.
+			this.moveTask({ task: task, calendar: calendar, parent: parent })
+		},
+
+		/**
+		 * Function to add a task to a collection.
+		 *
+		 * @param {Object} $event The event which caused the change
+		 */
+		prepareCollecting: function($event) {
+			// The new collection --> make the moved task a member of this collection
+			// This is necessary for the collections {starred, today, completed, uncompleted and week}
+			var collectionAttribute = $event.to.attributes['collection-id']
+			if (collectionAttribute) {
+				var collectionId = collectionAttribute.value
+				console.debug('New collection id: ' + collectionId)
+			}
+		},
+	},
+}
+</script>

--- a/src/components/TheCollections/Calendar.vue
+++ b/src/components/TheCollections/Calendar.vue
@@ -39,30 +39,31 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 		<SortorderDropdown />
 		<div class="task-list">
 			<div class="grouped-tasks">
-				<ol :calendarId="calendarId"
+				<task-drag-container
+					:calendar-id="calendarId"
 					class="tasks"
-					collectionId="uncompleted"
+					collection-id="uncompleted"
 					type="list"
 				>
 					<Task v-for="task in sort(uncompletedRootTasks(calendar.tasks), sortOrder, sortDirection)"
 						:key="task.id"
 						:task="task"
 					/>
-				</ol>
+				</task-drag-container>
 				<h2 v-show="completedCount(calendarId)" class="heading-hiddentasks icon-triangle-s reactive" @click="toggleHidden">
 					{{ completedCountString }}
 				</h2>
-				<ol v-if="showHidden"
-					:calendarId="calendarId"
+				<task-drag-container v-if="showHidden"
+					:calendar-id="calendarId"
 					class="completed-tasks"
-					collectionId="completed"
+					collection-id="completed"
 					type="list"
 				>
 					<Task v-for="task in sort(completedRootTasks(calendar.tasks), sortOrder, sortDirection)"
 						:key="task.id"
 						:task="task"
 					/>
-				</ol>
+				</task-drag-container>
 				<LoadCompletedButton :calendar="calendar" />
 			</div>
 		</div>
@@ -75,12 +76,14 @@ import { sort } from '../../store/storeHelper'
 import SortorderDropdown from '../SortorderDropdown'
 import LoadCompletedButton from '../LoadCompletedButton'
 import Task from '../Task'
+import TaskDragContainer from '../TaskDragContainer'
 
 export default {
 	components: {
 		'Task': Task,
 		'SortorderDropdown': SortorderDropdown,
-		'LoadCompletedButton': LoadCompletedButton
+		'LoadCompletedButton': LoadCompletedButton,
+		TaskDragContainer,
 	},
 	props: {
 		calendarId: {
@@ -146,7 +149,15 @@ export default {
 		addTask: function() {
 			this.createTask({ summary: this.newTaskName, calendar: this.calendar })
 			this.newTaskName = ''
-		}
+		},
+
+		onMove: function($event, $originalEvent) {
+			console.debug($event)
+			console.debug($event.target)
+			console.debug($event.to)
+			// console.debug('target: ' + $event.target.attributes['task-id'].value)
+			// console.debug('to: ' + $event.to.attributes['task-id'].value)
+		},
 	}
 }
 </script>

--- a/src/components/TheCollections/General.vue
+++ b/src/components/TheCollections/General.vue
@@ -45,8 +45,9 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 				<h2 class="heading">
 					{{ calendar.displayName }}
 				</h2>
-				<ol :calendarID="calendar.id"
-					:collectionID="collectionId"
+				<task-drag-container
+					:calendar-id="calendar.id"
+					:collection-id="collectionId"
 					class="tasks"
 					type="list"
 				>
@@ -54,7 +55,7 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 						:key="task.id"
 						:task="task"
 					/>
-				</ol>
+				</task-drag-container>
 				<LoadCompletedButton v-if="collectionId === 'completed'" :calendar="calendar" />
 			</div>
 		</div>
@@ -67,12 +68,14 @@ import { sort, isTaskInList, isParentInList } from '../../store/storeHelper'
 import SortorderDropdown from '../SortorderDropdown'
 import LoadCompletedButton from '../LoadCompletedButton'
 import TaskBody from '../Task'
+import TaskDragContainer from '../TaskDragContainer'
 
 export default {
 	components: {
 		'TaskBody': TaskBody,
 		'SortorderDropdown': SortorderDropdown,
-		'LoadCompletedButton': LoadCompletedButton
+		'LoadCompletedButton': LoadCompletedButton,
+		TaskDragContainer,
 	},
 	data() {
 		return {

--- a/src/components/TheCollections/Week.vue
+++ b/src/components/TheCollections/Week.vue
@@ -28,16 +28,16 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 				<h2 class="heading">
 					{{ day.diff | formatDay }}
 				</h2>
-				<ol collectionID="week"
+				<task-drag-container
+					collection-id="week"
 					class="tasks"
-					listID=""
 					type="list"
 				>
 					<TaskBody v-for="task in sort(day.tasks, sortOrder, sortDirection)"
 						:key="task.id"
 						:task="task"
 					/>
-				</ol>
+				</task-drag-container>
 			</div>
 		</div>
 	</div>
@@ -48,11 +48,13 @@ import { mapGetters } from 'vuex'
 import { sort } from '../../store/storeHelper'
 import SortorderDropdown from '../SortorderDropdown'
 import TaskBody from '../Task'
+import TaskDragContainer from '../TaskDragContainer'
 
 export default {
 	components: {
 		'TaskBody': TaskBody,
-		'SortorderDropdown': SortorderDropdown
+		'SortorderDropdown': SortorderDropdown,
+		TaskDragContainer,
 	},
 	filters: {
 		formatDay: function(day) {

--- a/src/components/TheCollections/Week.vue
+++ b/src/components/TheCollections/Week.vue
@@ -29,7 +29,7 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 					{{ day.diff | formatDay }}
 				</h2>
 				<task-drag-container
-					collection-id="week"
+					:collection-id="'week-' + day.diff"
 					class="tasks"
 					type="list"
 				>

--- a/src/components/TheDetails.vue
+++ b/src/components/TheDetails.vue
@@ -516,7 +516,7 @@ export default {
 			'setDue',
 			'setStart',
 			'toggleAllDay',
-			'moveTaskToCalendar',
+			'moveTask',
 		]),
 
 		removeTask: function() {
@@ -728,7 +728,7 @@ export default {
 		},
 
 		async changeCalendar(calendar) {
-			const task = await this.moveTaskToCalendar({ task: this.task, calendar: calendar })
+			const task = await this.moveTask({ task: this.task, calendar: calendar })
 			// If we are in a calendar view, we have to navigate to the new calendar.
 			if (this.$route.params.calendarId) {
 				this.$router.push('/calendars/' + task.calendar.id + '/tasks/' + task.uri)

--- a/src/store/calendars.js
+++ b/src/store/calendars.js
@@ -489,7 +489,8 @@ const actions = {
 
 						// If necessary, add the tasks as subtasks to parent tasks already present in the store.
 						if (!related) {
-							context.commit('addTaskToParent', parent)
+							let parentParent = context.getters.getTaskByUid(parent.related)
+							context.commit('addTaskToParent', { task: parent, parent: parentParent })
 						}
 					}
 				)


### PR DESCRIPTION
This PR aims to implement drag and drop in order to

- [x] Move subtasks
- [x] Move tasks between calendars
- [x] Star a task, set the date to today or complete a task by dropping on corresponding collection