### PR TITLE
feat: adds task priority information to DOM

### DIFF
--- a/src/components/Task.vue
+++ b/src/components/Task.vue
@@ -24,6 +24,7 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 	<li	v-show="showTask"
 		:task-id="task.uri"
 		:class="{done: task.completed}"
+		:data-priority="[task.priority]"
 		class="task-item"
 	>
 		<div :task-id="task.uri"


### PR DESCRIPTION
By adding task priority information to the DOM the tasks app is further customizable by peoples external scripts/browser plugins/custom styling. 

A personal use case is that I would like to have a wider variety of star colours that depend on the task priority, not just if the star is less than/greater than 5. Using a custom CSS app in NextCloud, coupled with this change, I can configure the star colours however I please.