### PR TITLE
Add comments to unclear translations

### DIFF
--- a/src/components/SortorderDropdown.vue
+++ b/src/components/SortorderDropdown.vue
@@ -87,6 +87,7 @@ export default {
 				{
 					id: 'created',
 					icon: 'icon-calendar',
+					// TRANSLATORS The date at which a task was created.
 					text: t('tasks', 'Created date'),
 					hint: t('tasks', 'Sort by created date and summary.')
 				},

--- a/src/components/TheDetails.vue
+++ b/src/components/TheDetails.vue
@@ -333,15 +333,22 @@ export default {
 			if (valid(date)) {
 				if (date.isDate) {
 					return moment(date, 'YYYYMMDDTHHmmss').calendar(null, {
+						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. Please translate the string and keep the brackets.
 						sameDay: t('tasks', '[Starts today]'),
+						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. Please translate the string and keep the brackets.
 						nextDay: t('tasks', '[Starts tomorrow]'),
+						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LL" will be replaced with a date, e.g. 'September 4 1986'. Please translate the string, and keep the brackets and the "LL".
 						nextWeek: t('tasks', '[Starts on] LL'),
+						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. Please translate the string and keep the brackets.
 						lastDay: t('tasks', '[Started yesterday]'),
+						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LL" will be replaced with a date, e.g. 'September 4 1986'. Please translate the string, and keep the brackets and the "LL".
 						lastWeek: t('tasks', '[Started on] LL'),
 						sameElse: function(now) {
 							if (this.isBefore(now)) {
+								// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LL" will be replaced with a date, e.g. 'September 4 1986'. Please translate the string, and keep the brackets and the "LL".
 								return t('tasks', '[Started on] LL')
 							} else {
+								// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LL" will be replaced with a date, e.g. 'September 4 1986'. Please translate the string, and keep the brackets and the "LL".
 								return t('tasks', '[Starts on] LL')
 							}
 						}
@@ -350,19 +357,27 @@ export default {
 					return moment(date, 'YYYYMMDDTHHmmss').calendar(null, {
 						sameDay: function(now) {
 							if (this.isBefore(now)) {
+								// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LT" will be replaced with a time, e.g. '08:30 PM'. Please translate the string and keep the brackets and the "LT".
 								return t('tasks', '[Started today at] LT')
 							} else {
+								// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LT" will be replaced with a time, e.g. '08:30 PM'. Please translate the string and keep the brackets and the "LT".
 								return t('tasks', '[Starts today at] LT')
 							}
 						},
+						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LT" will be replaced with a time, e.g. '08:30 PM'. Please translate the string and keep the brackets and the "LT".
 						nextDay: t('tasks', '[Starts tomorrow at] LT'),
+						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LL" will be replaced with a date, e.g. 'September 4 1986' and "LT" will be replaced with a time, e.g. '08:30 PM'. Please translate the string and keep the brackets the "LL" and the "LT".
 						nextWeek: t('tasks', '[Starts on] LL [at] LT'),
+						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LT" will be replaced with a time, e.g. '08:30 PM'. Please translate the string and keep the brackets and the "LT".
 						lastDay: t('tasks', '[Started yesterday at] LT'),
+						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LL" will be replaced with a date, e.g. 'September 4 1986' and "LT" will be replaced with a time, e.g. '08:30 PM'. Please translate the string and keep the brackets the "LL" and the "LT".
 						lastWeek: t('tasks', '[Started on] LL [at] LT'),
 						sameElse: function(now) {
 							if (this.isBefore(now)) {
+								// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LL" will be replaced with a date, e.g. 'September 4 1986' and "LT" will be replaced with a time, e.g. '08:30 PM'. Please translate the string and keep the brackets the "LL" and the "LT".
 								return t('tasks', '[Started on] LL [at] LT')
 							} else {
+								// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LL" will be replaced with a date, e.g. 'September 4 1986' and "LT" will be replaced with a time, e.g. '08:30 PM'. Please translate the string and keep the brackets the "LL" and the "LT".
 								return t('tasks', '[Starts on] LL [at] LT')
 							}
 						}
@@ -376,15 +391,22 @@ export default {
 			if (valid(date)) {
 				if (date.isDate) {
 					return moment(date, 'YYYYMMDDTHHmmss').calendar(null, {
+						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. Please translate the string and keep the brackets.
 						sameDay: t('tasks', '[Due today]'),
+						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. Please translate the string and keep the brackets.
 						nextDay: t('tasks', '[Due tomorrow]'),
+						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LL" will be replaced with a date, e.g. 'September 4 1986'. Please translate the string and keep the brackets and the "LL".
 						nextWeek: t('tasks', '[Due on] LL'),
+						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. Please translate the string, but keep the brackets.
 						lastDay: t('tasks', '[Was due yesterday]'),
+						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LL" will be replaced with a date, e.g. 'September 4 1986'. Please translate the string, but keep the brackets and the "LL".
 						lastWeek: t('tasks', '[Was due on] LL'),
 						sameElse: function(now) {
 							if (this.isBefore(now)) {
+								// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. Please translate the string, but keep the brackets and the "LL".
 								return t('tasks', '[Was due on] LL')
 							} else {
+								// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. Please translate the string, but keep the brackets and the "LL".
 								return t('tasks', '[Due on] LL')
 							}
 						}
@@ -393,19 +415,27 @@ export default {
 					return moment(date, 'YYYYMMDDTHHmmss').calendar(null, {
 						sameDay: function(now) {
 							if (this.isBefore(now)) {
+								// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LT" will be replaced with a time, e.g. '08:30 PM'. Please translate the string and keep the brackets and the "LT".
 								return t('tasks', '[Was due today at] LT')
 							} else {
+								// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LT" will be replaced with a time, e.g. '08:30 PM'. Please translate the string and keep the brackets and the "LT".
 								return t('tasks', '[Due today at] LT')
 							}
 						},
+						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LT" will be replaced with a time, e.g. '08:30 PM'. Please translate the string and keep the brackets and the "LT".
 						nextDay: t('tasks', '[Due tomorrow at] LT'),
+						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LT" will be replaced with a time, e.g. '08:30 PM'. Please translate the string and keep the brackets and the "LT".
 						nextWeek: t('tasks', '[Due on] LL [at] LT'),
+						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LT" will be replaced with a time, e.g. '08:30 PM'. Please translate the string and keep the brackets and the "LT".
 						lastDay: t('tasks', '[Was due yesterday at] LT'),
+						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LL" will be replaced with a date, e.g. 'September 4 1986' and "LT" will be replaced with a time, e.g. '08:30 PM'. Please translate the string and keep the brackets the "LL" and the "LT".
 						lastWeek: t('tasks', '[Was due on] LL [at] LT'),
 						sameElse: function(now) {
 							if (this.isBefore(now)) {
+								// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LL" will be replaced with a date, e.g. 'September 4 1986' and "LT" will be replaced with a time, e.g. '08:30 PM'. Please translate the string and keep the brackets the "LL" and the "LT".
 								return t('tasks', '[Was due on] LL [at] LT')
 							} else {
+								// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LL" will be replaced with a date, e.g. 'September 4 1986' and "LT" will be replaced with a time, e.g. '08:30 PM'. Please translate the string and keep the brackets the "LL" and the "LT".
 								return t('tasks', '[Due on] LL [at] LT')
 							}
 						}


### PR DESCRIPTION
Some strings were not translated by the translators on Transifex, because square brackets were interpreted as escaping entities to prevent translation e.g. https://github.com/nextcloud/tasks/blob/d0ef43b4797bae5423ba63cb02e7048776bd0ed6/l10n/de.js#L58-L79.

Square brackets are used by moment.js to escape a string from beeing intertpreted as a formating command, hence the strings inside still need to be translated.

I added comments on all occurences to clarify this.