### PR TITLE
Improve drag and drop experience

### DIFF
--- a/css/src/style.scss
+++ b/css/src/style.scss
@@ -458,10 +458,6 @@
 		background-color: rgba( $color-primary, .3 );
 	}
 
-	&.dragover > div.subtasks-container > ol {
-		min-height: 37px;
-	}
-
 	.subtasks-container {
 		margin-left: 35px;
 

--- a/src/components/TaskDragContainer.vue
+++ b/src/components/TaskDragContainer.vue
@@ -26,7 +26,7 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 		:move="onMove"
 		@end="onEnd"
 	>
-		<slot :move="onMove" />
+		<slot />
 	</draggable>
 </template>
 
@@ -54,16 +54,6 @@ export default {
 		]),
 
 		/**
-		 * Called when a task is dragged.
-		 *
-		 * @param {Object} $event The event which caused the move
-		 */
-		onMove: function($event) {
-			this.cleanUpDragging()
-			$event.related.classList.add('dragover')
-		},
-
-		/**
 		 * Called when a task is dropped.
 		 *
 		 * @param {Object} $event The event which caused the drop
@@ -78,18 +68,7 @@ export default {
 			// Move the task to a new calendar or parent.
 			this.prepareMoving(task, $event)
 			this.prepareCollecting(task, $event)
-			this.cleanUpDragging()
 			$event.stopPropagation()
-		},
-
-		/**
-		 * Called when we stopped dragging. Cleans up temporarily added classes.
-		 */
-		cleanUpDragging: function() {
-			var items = document.getElementsByClassName('task-item')
-			for (let i = 0; i < items.length; i++) {
-				items[i].classList.remove('dragover')
-			}
 		},
 
 		/**


### PR DESCRIPTION
With https://github.com/nextcloud/tasks/pull/418 and the included update to Sortable.js 1.9.0 (specifically https://github.com/SortableJS/Sortable/issues/1487), we don't need to force the subtasks container to be visible in order to drop a task as the only subtask of a parent task.

Hence, there is no empty slot below a hovered task anymore, which makes the drag-and-drop experience less "janky" (@skjnldsv https://github.com/nextcloud/tasks/pull/236#issuecomment-489620659) 😉 
