### PR TITLE
Disable drag-and-drop for read-only calendars

### DIFF
--- a/src/components/Task.vue
+++ b/src/components/Task.vue
@@ -116,6 +116,7 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 			<task-drag-container v-if="showSubtasks"
 				:task-id="task.uri"
 				:calendar-id="task.calendar.uri"
+				:disabled="task.calendar.readOnly"
 			>
 				<TaskBodyComponent v-for="subtask in filteredSubtasks"
 					:key="subtask.uid"

--- a/src/components/TaskDragContainer.vue
+++ b/src/components/TaskDragContainer.vue
@@ -22,7 +22,7 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 <template>
 	<draggable tag="ol"
 		:list="['']"
-		v-bind="{group: 'tasks', swapThreshold: 0.30, delay: 500, delayOnTouchOnly: true, touchStartThreshold: 3}"
+		v-bind="{group: 'tasks', swapThreshold: 0.30, delay: 500, delayOnTouchOnly: true, touchStartThreshold: 3, disabled: disabled}"
 		@end="onEnd"
 	>
 		<slot />
@@ -36,6 +36,12 @@ import { mapGetters, mapActions } from 'vuex'
 export default {
 	components: {
 		draggable,
+	},
+	props: {
+		disabled: {
+			type: Boolean,
+			default: false,
+		}
 	},
 	computed: {
 		...mapGetters({

--- a/src/components/TheCollections/Calendar.vue
+++ b/src/components/TheCollections/Calendar.vue
@@ -41,6 +41,7 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 			<div class="grouped-tasks">
 				<task-drag-container
 					:calendar-id="calendarId"
+					:disabled="calendar.readOnly"
 					class="tasks"
 					collection-id="uncompleted"
 					type="list"
@@ -55,6 +56,7 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 				</h2>
 				<task-drag-container v-if="showHidden"
 					:calendar-id="calendarId"
+					:disabled="calendar.readOnly"
 					class="completed-tasks"
 					collection-id="completed"
 					type="list"

--- a/src/components/TheCollections/General.vue
+++ b/src/components/TheCollections/General.vue
@@ -48,6 +48,7 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 				<task-drag-container
 					:calendar-id="calendar.id"
 					:collection-id="collectionId"
+					:disabled="calendar.readOnly"
 					class="tasks"
 					type="list"
 				>

--- a/src/components/TheCollections/Week.vue
+++ b/src/components/TheCollections/Week.vue
@@ -30,6 +30,7 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 				</h2>
 				<task-drag-container
 					:collection-id="'week-' + day.diff"
+					:disabled="calendar.readOnly"
 					class="tasks"
 					type="list"
 				>


### PR DESCRIPTION
This disables drag-and-drop for read-only calendars. Follow-up to #523.