### PR TITLE
Fix translate function for Chrome 77 Beta

### DIFF
--- a/src/components/Task.vue
+++ b/src/components/Task.vue
@@ -157,9 +157,9 @@ export default {
 		formatDate: function(date) {
 			return valid(date)
 				? moment(date, 'YYYYMMDDTHHmmss').calendar(null, {
-					lastDay: t('tasks', '[Yesterday]'),
-					sameDay: t('tasks', '[Today]'),
-					nextDay: t('tasks', '[Tomorrow]'),
+					lastDay: OCA.Tasks.$t('tasks', '[Yesterday]'),
+					sameDay: OCA.Tasks.$t('tasks', '[Today]'),
+					nextDay: OCA.Tasks.$t('tasks', '[Tomorrow]'),
 					lastWeek: 'L',
 					nextWeek: 'L',
 					sameElse: 'L'

--- a/src/components/TheCollections/Week.vue
+++ b/src/components/TheCollections/Week.vue
@@ -61,9 +61,9 @@ export default {
 			var date = moment().add(day, 'day')
 			var dayString
 			if (day === 0) {
-				dayString = t('tasks', 'Today')
+				dayString = OCA.Tasks.$t('tasks', 'Today')
 			} else if (day === 1) {
-				dayString = t('tasks', 'Tomorrow')
+				dayString = OCA.Tasks.$t('tasks', 'Tomorrow')
 			} else {
 				dayString = date.format('dddd')
 			}

--- a/src/components/TheDetails.vue
+++ b/src/components/TheDetails.vue
@@ -372,22 +372,22 @@ export default {
 				if (date.isDate) {
 					return moment(date, 'YYYYMMDDTHHmmss').calendar(null, {
 						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. Please translate the string and keep the brackets.
-						sameDay: t('tasks', '[Starts today]'),
+						sameDay: OCA.Tasks.$t('tasks', '[Starts today]'),
 						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. Please translate the string and keep the brackets.
-						nextDay: t('tasks', '[Starts tomorrow]'),
+						nextDay: OCA.Tasks.$t('tasks', '[Starts tomorrow]'),
 						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LL" will be replaced with a date, e.g. 'September 4 1986'. Please translate the string, and keep the brackets and the "LL".
-						nextWeek: t('tasks', '[Starts on] LL'),
+						nextWeek: OCA.Tasks.$t('tasks', '[Starts on] LL'),
 						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. Please translate the string and keep the brackets.
-						lastDay: t('tasks', '[Started yesterday]'),
+						lastDay: OCA.Tasks.$t('tasks', '[Started yesterday]'),
 						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LL" will be replaced with a date, e.g. 'September 4 1986'. Please translate the string, and keep the brackets and the "LL".
-						lastWeek: t('tasks', '[Started on] LL'),
+						lastWeek: OCA.Tasks.$t('tasks', '[Started on] LL'),
 						sameElse: function(now) {
 							if (this.isBefore(now)) {
 								// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LL" will be replaced with a date, e.g. 'September 4 1986'. Please translate the string, and keep the brackets and the "LL".
-								return t('tasks', '[Started on] LL')
+								return OCA.Tasks.$t('tasks', '[Started on] LL')
 							} else {
 								// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LL" will be replaced with a date, e.g. 'September 4 1986'. Please translate the string, and keep the brackets and the "LL".
-								return t('tasks', '[Starts on] LL')
+								return OCA.Tasks.$t('tasks', '[Starts on] LL')
 							}
 						}
 					})
@@ -396,33 +396,33 @@ export default {
 						sameDay: function(now) {
 							if (this.isBefore(now)) {
 								// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LT" will be replaced with a time, e.g. '08:30 PM'. Please translate the string and keep the brackets and the "LT".
-								return t('tasks', '[Started today at] LT')
+								return OCA.Tasks.$t('tasks', '[Started today at] LT')
 							} else {
 								// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LT" will be replaced with a time, e.g. '08:30 PM'. Please translate the string and keep the brackets and the "LT".
-								return t('tasks', '[Starts today at] LT')
+								return OCA.Tasks.$t('tasks', '[Starts today at] LT')
 							}
 						},
 						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LT" will be replaced with a time, e.g. '08:30 PM'. Please translate the string and keep the brackets and the "LT".
-						nextDay: t('tasks', '[Starts tomorrow at] LT'),
+						nextDay: OCA.Tasks.$t('tasks', '[Starts tomorrow at] LT'),
 						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LL" will be replaced with a date, e.g. 'September 4 1986' and "LT" will be replaced with a time, e.g. '08:30 PM'. Please translate the string and keep the brackets the "LL" and the "LT".
-						nextWeek: t('tasks', '[Starts on] LL [at] LT'),
+						nextWeek: OCA.Tasks.$t('tasks', '[Starts on] LL [at] LT'),
 						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LT" will be replaced with a time, e.g. '08:30 PM'. Please translate the string and keep the brackets and the "LT".
-						lastDay: t('tasks', '[Started yesterday at] LT'),
+						lastDay: OCA.Tasks.$t('tasks', '[Started yesterday at] LT'),
 						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LL" will be replaced with a date, e.g. 'September 4 1986' and "LT" will be replaced with a time, e.g. '08:30 PM'. Please translate the string and keep the brackets the "LL" and the "LT".
-						lastWeek: t('tasks', '[Started on] LL [at] LT'),
+						lastWeek: OCA.Tasks.$t('tasks', '[Started on] LL [at] LT'),
 						sameElse: function(now) {
 							if (this.isBefore(now)) {
 								// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LL" will be replaced with a date, e.g. 'September 4 1986' and "LT" will be replaced with a time, e.g. '08:30 PM'. Please translate the string and keep the brackets the "LL" and the "LT".
-								return t('tasks', '[Started on] LL [at] LT')
+								return OCA.Tasks.$t('tasks', '[Started on] LL [at] LT')
 							} else {
 								// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LL" will be replaced with a date, e.g. 'September 4 1986' and "LT" will be replaced with a time, e.g. '08:30 PM'. Please translate the string and keep the brackets the "LL" and the "LT".
-								return t('tasks', '[Starts on] LL [at] LT')
+								return OCA.Tasks.$t('tasks', '[Starts on] LL [at] LT')
 							}
 						}
 					})
 				}
 			} else {
-				return t('tasks', 'Set start date')
+				return OCA.Tasks.$t('tasks', 'Set start date')
 			}
 		},
 		formatDueDate: function(date) {
@@ -430,22 +430,22 @@ export default {
 				if (date.isDate) {
 					return moment(date, 'YYYYMMDDTHHmmss').calendar(null, {
 						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. Please translate the string and keep the brackets.
-						sameDay: t('tasks', '[Due today]'),
+						sameDay: OCA.Tasks.$t('tasks', '[Due today]'),
 						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. Please translate the string and keep the brackets.
-						nextDay: t('tasks', '[Due tomorrow]'),
+						nextDay: OCA.Tasks.$t('tasks', '[Due tomorrow]'),
 						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LL" will be replaced with a date, e.g. 'September 4 1986'. Please translate the string and keep the brackets and the "LL".
-						nextWeek: t('tasks', '[Due on] LL'),
+						nextWeek: OCA.Tasks.$t('tasks', '[Due on] LL'),
 						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. Please translate the string, but keep the brackets.
-						lastDay: t('tasks', '[Was due yesterday]'),
+						lastDay: OCA.Tasks.$t('tasks', '[Was due yesterday]'),
 						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LL" will be replaced with a date, e.g. 'September 4 1986'. Please translate the string, but keep the brackets and the "LL".
-						lastWeek: t('tasks', '[Was due on] LL'),
+						lastWeek: OCA.Tasks.$t('tasks', '[Was due on] LL'),
 						sameElse: function(now) {
 							if (this.isBefore(now)) {
 								// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. Please translate the string, but keep the brackets and the "LL".
-								return t('tasks', '[Was due on] LL')
+								return OCA.Tasks.$t('tasks', '[Was due on] LL')
 							} else {
 								// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. Please translate the string, but keep the brackets and the "LL".
-								return t('tasks', '[Due on] LL')
+								return OCA.Tasks.$t('tasks', '[Due on] LL')
 							}
 						}
 					})
@@ -454,48 +454,48 @@ export default {
 						sameDay: function(now) {
 							if (this.isBefore(now)) {
 								// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LT" will be replaced with a time, e.g. '08:30 PM'. Please translate the string and keep the brackets and the "LT".
-								return t('tasks', '[Was due today at] LT')
+								return OCA.Tasks.$t('tasks', '[Was due today at] LT')
 							} else {
 								// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LT" will be replaced with a time, e.g. '08:30 PM'. Please translate the string and keep the brackets and the "LT".
-								return t('tasks', '[Due today at] LT')
+								return OCA.Tasks.$t('tasks', '[Due today at] LT')
 							}
 						},
 						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LT" will be replaced with a time, e.g. '08:30 PM'. Please translate the string and keep the brackets and the "LT".
-						nextDay: t('tasks', '[Due tomorrow at] LT'),
+						nextDay: OCA.Tasks.$t('tasks', '[Due tomorrow at] LT'),
 						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LT" will be replaced with a time, e.g. '08:30 PM'. Please translate the string and keep the brackets and the "LT".
-						nextWeek: t('tasks', '[Due on] LL [at] LT'),
+						nextWeek: OCA.Tasks.$t('tasks', '[Due on] LL [at] LT'),
 						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LT" will be replaced with a time, e.g. '08:30 PM'. Please translate the string and keep the brackets and the "LT".
-						lastDay: t('tasks', '[Was due yesterday at] LT'),
+						lastDay: OCA.Tasks.$t('tasks', '[Was due yesterday at] LT'),
 						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LL" will be replaced with a date, e.g. 'September 4 1986' and "LT" will be replaced with a time, e.g. '08:30 PM'. Please translate the string and keep the brackets the "LL" and the "LT".
-						lastWeek: t('tasks', '[Was due on] LL [at] LT'),
+						lastWeek: OCA.Tasks.$t('tasks', '[Was due on] LL [at] LT'),
 						sameElse: function(now) {
 							if (this.isBefore(now)) {
 								// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LL" will be replaced with a date, e.g. 'September 4 1986' and "LT" will be replaced with a time, e.g. '08:30 PM'. Please translate the string and keep the brackets the "LL" and the "LT".
-								return t('tasks', '[Was due on] LL [at] LT')
+								return OCA.Tasks.$t('tasks', '[Was due on] LL [at] LT')
 							} else {
 								// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. "LL" will be replaced with a date, e.g. 'September 4 1986' and "LT" will be replaced with a time, e.g. '08:30 PM'. Please translate the string and keep the brackets the "LL" and the "LT".
-								return t('tasks', '[Due on] LL [at] LT')
+								return OCA.Tasks.$t('tasks', '[Due on] LL [at] LT')
 							}
 						}
 					})
 				}
 			} else {
-				return t('tasks', 'Set due date')
+				return OCA.Tasks.$t('tasks', 'Set due date')
 			}
 		},
 		priority: function(priority) {
 			if (+priority === 0) {
-				return t('tasks', 'No priority assigned')
+				return OCA.Tasks.$t('tasks', 'No priority assigned')
 			} else if (+priority > 0 && +priority < 5) {
-				return t('tasks', 'Priority {priority}: high', { priority: priority })
+				return OCA.Tasks.$t('tasks', 'Priority {priority}: high', { priority: priority })
 			} else if (+priority === 5) {
-				return t('tasks', 'Priority {priority}: medium', { priority: priority })
+				return OCA.Tasks.$t('tasks', 'Priority {priority}: medium', { priority: priority })
 			} else if (+priority > 5 && +priority < 10) {
-				return t('tasks', 'Priority {priority}: low', { priority: priority })
+				return OCA.Tasks.$t('tasks', 'Priority {priority}: low', { priority: priority })
 			}
 		},
 		complete: function(complete) {
-			return t('tasks', '{percent} % completed', { percent: complete })
+			return OCA.Tasks.$t('tasks', '{percent} % completed', { percent: complete })
 		}
 	},
 	data: function() {

--- a/src/main.js
+++ b/src/main.js
@@ -57,11 +57,18 @@ if (!OCA.Tasks) {
 	OCA.Tasks = {}
 }
 
-Vue.prototype.$t = t
-Vue.prototype.$n = n
+Vue.prototype.$t = function() {
+	return t.apply(null, arguments).toString()
+}
+Vue.prototype.$n = function() {
+	return n.apply(null, arguments).toString()
+}
 Vue.prototype.$OC = OC
 Vue.prototype.$OCA = OCA
 Vue.prototype.$appVersion = $appVersion
+
+OCA.Tasks.$t = Vue.prototype.$t
+OCA.Tasks.$n = Vue.prototype.$n
 
 OCA.Tasks.App = new Vue({
 	el: '.app-tasks',

--- a/src/store/tasks.js
+++ b/src/store/tasks.js
@@ -660,7 +660,7 @@ const actions = {
 				})
 				.catch((error) => {
 					console.debug(error)
-					task.syncstatus = new TaskStatus('error', t('tasks', 'Could not delete the task.'))
+					task.syncstatus = new TaskStatus('error', OCA.Tasks.$t('tasks', 'Could not delete the task.'))
 				})
 		} else {
 			deleteTaskFromStore()
@@ -699,10 +699,10 @@ const actions = {
 
 		if (!task.conflict) {
 			task.dav.data = vCalendar
-			task.syncstatus = new TaskStatus('sync', t('tasks', 'Synchronizing to the server.'))
+			task.syncstatus = new TaskStatus('sync', OCA.Tasks.$t('tasks', 'Synchronizing to the server.'))
 			return task.dav.update()
 				.then((response) => {
-					task.syncstatus = new TaskStatus('success', t('tasks', 'Task successfully saved to server.'))
+					task.syncstatus = new TaskStatus('success', OCA.Tasks.$t('tasks', 'Task successfully saved to server.'))
 				})
 				.catch((error) => {
 					// Wrong etag, we most likely have a conflict
@@ -710,13 +710,13 @@ const actions = {
 						// Saving the new etag so that the user can manually
 						// trigger a fetchCompleteData without any further errors
 						task.conflict = error.xhr.getResponseHeader('etag')
-						task.syncstatus = new TaskStatus('refresh', t('tasks', 'Could not update the task because it was changed on the server. Please click to refresh it, local changes will be discarded.'), 'fetchFullTask')
+						task.syncstatus = new TaskStatus('refresh', OCA.Tasks.$t('tasks', 'Could not update the task because it was changed on the server. Please click to refresh it, local changes will be discarded.'), 'fetchFullTask')
 					} else {
-						task.syncstatus = new TaskStatus('error', t('tasks', 'Could not update the task.'))
+						task.syncstatus = new TaskStatus('error', OCA.Tasks.$t('tasks', 'Could not update the task.'))
 					}
 				})
 		} else {
-			task.syncstatus = new TaskStatus('refresh', t('tasks', 'Could not update the task because it was changed on the server. Please click to refresh it, local changes will be discared.'), 'fetchFullTask')
+			task.syncstatus = new TaskStatus('refresh', OCA.Tasks.$t('tasks', 'Could not update the task because it was changed on the server. Please click to refresh it, local changes will be discared.'), 'fetchFullTask')
 		}
 	},
 


### PR DESCRIPTION
This fixes an issue occuring in Chrome 77 Beta, see #566. Although this would fix the issue and not cause any other problems (as far as I know atm), I am a bit reluctant to actually merge this because:

- we fix an issue occuring in the Beta release of Chrome which might not occur anymore in the stable release
- in case the issue persists in the Chrome stable release, the translate function `t(...)` should actually be adjusted in Nextcloud server and not in the apps.

As a conclusion, I will for now not merge this fix but wait how things go with Chrome stable. In case it persists, we have a fix at hand and can react quickly. For everyone that wants/has to use Chrome Beta here is a version of the app containing the fix:
[tasks.zip](https://github.com/nextcloud/tasks/files/3595292/tasks.zip)

