### PR TITLE
Load task from server if not found locally

### DIFF
--- a/src/components/Task.vue
+++ b/src/components/Task.vue
@@ -291,6 +291,13 @@ export default {
 			return checkSubtasksOpen(this.task.subTasks)
 		},
 	},
+
+	created() {
+		if (!this.task.loadedCompleted && this.$route.params.taskId === this.task.uri) {
+			this.getTasksFromCalendar({ calendar: this.task.calendar, completed: true, related: this.task.uid })
+		}
+	},
+
 	methods: {
 		...mapActions([
 			'toggleCompleted',

--- a/src/store/calendars.js
+++ b/src/store/calendars.js
@@ -504,6 +504,14 @@ const actions = {
 							return list
 						}, parent.subTasks)
 
+						// In case we already have subtasks of this task in the store, add them as well.
+						const subTasksInStore = context.getters.getTasksByParent(parent)
+						subTasksInStore.forEach(
+							subTask => {
+								context.commit('addTaskToParent', { task: subTask, parent: parent })
+							}
+						)
+
 						// If necessary, add the tasks as subtasks to parent tasks already present in the store.
 						if (!related) {
 							const parentParent = context.getters.getTaskByUid(parent.related)

--- a/src/store/cdav-requests.js
+++ b/src/store/cdav-requests.js
@@ -71,6 +71,33 @@ function findVTODObyState(calendar, completed, related) {
 	return calendar.dav.calendarQuery([query])
 }
 
+function findVTODObyUid(calendar, taskUid) {
+	const query = {
+		name: [NS.IETF_CALDAV, 'comp-filter'],
+		attributes: [
+			['name', 'VCALENDAR']
+		],
+		children: [{
+			name: [NS.IETF_CALDAV, 'comp-filter'],
+			attributes: [
+				['name', 'VTODO']
+			]
+		}]
+	}
+	query.children[0].children = [{
+		name: [NS.IETF_CALDAV, 'prop-filter'],
+		attributes: [
+			['name', 'uid']
+		],
+		children: [{
+			name: [NS.IETF_CALDAV, 'text-match'],
+			value: taskUid
+		}]
+	}]
+	return calendar.dav.calendarQuery([query])
+}
+
 export {
-	findVTODObyState
+	findVTODObyState,
+	findVTODObyUid
 }


### PR DESCRIPTION
This implements #606. When a requested task is not found locally, we try to load it from the server.

Todo:
- [x] We should also try to load the ancestor tasks (if any) of the requested task, so we can properly show the subtasks tree
- [x] If we are in a collection view (e.g. /nextcloud/index.php/apps/tasks/#/collections/all/tasks/Nextcloud-lrr0rvhdcoqopte5k43n6.ics), we don't know which calendar a task belongs to, so we have to query all calendars I guess. Or is there a better way to find a task only knowing the last part of its `uri` @georgehrke @skjnldsv ?
- [x] Don't loose subtask relations for tasks alread present in store when loading tasks by Uri or UID

What I don't like so much is that I have to watch the calendar (https://github.com/nextcloud/tasks/pull/608/files#diff-128fe9ee0ed5aeabe3c64281c67285c0R584), but it was the easiest way to load a task only after the calendars are loaded.