### PR TITLE
Apply last all-day setting to newly created dates

### DIFF
--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -63,6 +63,7 @@ class SettingsService {
 			'showHidden' => (int)$this->settings->getUserValue($this->userId, $this->appName,'various_showHidden'),
 			'sortOrder' => (string)$this->settings->getUserValue($this->userId, $this->appName,'various_sortOrder'),
 			'sortDirection' => (bool)$this->settings->getUserValue($this->userId, $this->appName,'various_sortDirection'),
+			'allDay' => (bool)$this->settings->getUserValue($this->userId, $this->appName,'various_allDay'),
 			'userID' => $this->userId
 		);
 		return $settings;

--- a/src/components/TheCollections/General.vue
+++ b/src/components/TheCollections/General.vue
@@ -154,6 +154,7 @@ export default {
 			}
 			if (this.$route.params.collectionId === 'today') {
 				task.due = moment().startOf('day').format('YYYY-MM-DDTHH:mm:ss')
+				task.allDay = this.$store.state.settings.settings.allDay
 			}
 			if (this.$route.params.collectionId === 'current') {
 				task.start = moment().format('YYYY-MM-DDTHH:mm:ss')

--- a/src/components/TheDetails.vue
+++ b/src/components/TheDetails.vue
@@ -557,7 +557,7 @@ export default {
 				+ (this.task.completed ? ('<br />' + this.$t('tasks', 'Completed {date}', { date: this.task.completedDateMoment.calendar() })) : '')
 		},
 		isAllDayPossible: function() {
-			return !this.task.calendar.readOnly && (this.task.due || this.task.start)
+			return !this.task.calendar.readOnly && (this.task.due || this.task.start || ['start', 'due'].includes(this.edit))
 		},
 		priorityClass: function() {
 			if (+this.task.priority > 5) {

--- a/src/models/task.js
+++ b/src/models/task.js
@@ -405,6 +405,9 @@ export default class Task {
 		this.updateLastModified()
 		this._start = this.vtodo.getFirstPropertyValue('dtstart')
 		this._startMoment = moment(this._start, 'YYYYMMDDTHHmmss')
+		// Check all day setting
+		var d = this._due || this._start
+		this._allDay = d !== null && d.isDate
 	}
 
 	get startMoment() {
@@ -424,6 +427,9 @@ export default class Task {
 		this.updateLastModified()
 		this._due = this.vtodo.getFirstPropertyValue('due')
 		this._dueMoment = moment(this._due, 'YYYYMMDDTHHmmss')
+		// Check all day setting
+		var d = this._due || this._start
+		this._allDay = d !== null && d.isDate
 	}
 
 	get dueMoment() {

--- a/src/store/settings.js
+++ b/src/store/settings.js
@@ -47,6 +47,14 @@ const getters = {
 	 * @returns {String} The sort direction
 	 */
 	sortDirection: (state) => state.settings.sortDirection,
+
+	/**
+	 * Returns if all-day is default
+	 *
+	 * @param {Object} state The store data
+	 * @returns {String} Whether all-day is default
+	 */
+	allDay: (state) => state.settings.allDay,
 }
 
 const mutations = {

--- a/src/store/tasks.js
+++ b/src/store/tasks.js
@@ -1074,6 +1074,9 @@ const actions = {
 			return task
 		}
 		context.commit('toggleAllDay', task)
+		if (+context.rootState.settings.settings.allDay !== +task.allDay) {
+			context.dispatch('setSetting', { type: 'allDay', value: +task.allDay })
+		}
 		context.dispatch('scheduleTaskUpdate', task)
 	},
 

--- a/src/store/tasks.js
+++ b/src/store/tasks.js
@@ -446,8 +446,9 @@ const mutations = {
 	 * @param {Object} state The store data
 	 * @param {Task} task The task
 	 * @param {Moment} due The due date moment
+	 * @param {Boolean} allDay Whether the date is all-day
 	 */
-	setDue(state, { task, due }) {
+	setDue(state, { task, due, allDay }) {
 		if (due === null) {
 			// If the date is null, just set (remove) it.
 			Vue.set(task, 'due', due)
@@ -462,10 +463,10 @@ const mutations = {
 				} else {
 					start = due.clone()
 				}
-				Vue.set(task, 'start', momentToICALTime(start, task.allDay))
+				Vue.set(task, 'start', momentToICALTime(start, allDay))
 			}
 			// Set the due date, convert it to ICALTime first.
-			Vue.set(task, 'due', momentToICALTime(due, task.allDay))
+			Vue.set(task, 'due', momentToICALTime(due, allDay))
 		}
 	},
 
@@ -475,8 +476,9 @@ const mutations = {
 	 * @param {Object} state The store data
 	 * @param {Task} task The task
 	 * @param {Moment} start The start date moment
+	 * @param {Boolean} allDay Whether the date is all-day
 	 */
-	setStart(state, { task, start }) {
+	setStart(state, { task, start, allDay }) {
 		if (start === null) {
 			// If the date is null, just set (remove) it.
 			Vue.set(task, 'start', start)
@@ -491,10 +493,10 @@ const mutations = {
 				} else {
 					due = start.clone()
 				}
-				Vue.set(task, 'due', momentToICALTime(due, task.allDay))
+				Vue.set(task, 'due', momentToICALTime(due, allDay))
 			}
 			// Set the due date, convert it to ICALTime first.
-			Vue.set(task, 'start', momentToICALTime(start, task.allDay))
+			Vue.set(task, 'start', momentToICALTime(start, allDay))
 		}
 	},
 
@@ -1008,8 +1010,8 @@ const actions = {
 	 * @param {Object} context The store context
 	 * @param {Task} task The task to update
 	 */
-	async setDue(context, { task, due }) {
-		context.commit('setDue', { task: task, due: due })
+	async setDue(context, { task, due, allDay }) {
+		context.commit('setDue', { task: task, due: due, allDay: allDay })
 		context.dispatch('scheduleTaskUpdate', task)
 	},
 
@@ -1019,8 +1021,8 @@ const actions = {
 	 * @param {Object} context The store context
 	 * @param {Task} task The task to update
 	 */
-	async setStart(context, { task, start }) {
-		context.commit('setStart', { task: task, start: start })
+	async setStart(context, { task, start, allDay }) {
+		context.commit('setStart', { task: task, start: start, allDay: allDay })
 		context.dispatch('scheduleTaskUpdate', task)
 	},
 

--- a/src/store/tasks.js
+++ b/src/store/tasks.js
@@ -615,6 +615,9 @@ const actions = {
 		if (taskData.start) {
 			task.start = taskData.start
 		}
+		if (taskData.allDay) {
+			task.allDay = taskData.allDay
+		}
 		if (taskData.related) {
 			task.related = taskData.related
 			// Check that parent task is not completed, uncomplete if necessary.

--- a/tests/php/unit/Service/SettingsServiceTest.php
+++ b/tests/php/unit/Service/SettingsServiceTest.php
@@ -57,7 +57,8 @@ class SettingsServiceTest extends TestCase {
 			'showHidden' => 1,
 			'sortOrder' => 'default',
 			'sortDirection' => false,
-			'userID' => $this->userId
+			'userID' => $this->userId,
+			'allDay' => false
 		];
 
 		$map = [
@@ -86,6 +87,13 @@ class SettingsServiceTest extends TestCase {
 				$this->userId,
 				$this->appName,
 				'various_sortDirection',
+				'',
+				false
+			],
+			[
+				$this->userId,
+				$this->appName,
+				'various_allDay',
 				'',
 				false
 			]


### PR DESCRIPTION
Closes #615

As discussed in https://github.com/nextcloud/tasks/pull/656#issuecomment-539482473 applying the all-day setting to newly created dates is still to be done here.