### PR TITLE
Fix color of checked checkboxes in dark mode

### DIFF
--- a/css/src/style.scss
+++ b/css/src/style.scss
@@ -1194,7 +1194,7 @@
 
 input[type='checkbox'].checkbox {
 	&:checked + label::before {
-		background-image: var(--icon-checkmark-000);
+		background-image: var(--icon-checkmark-000) !important;
 		background-color: unset;
 		border-color: unset;
 	}


### PR DESCRIPTION
In dark mode checked checkboxes have a black checkmark at the moment. This PR fixes this:

![Screenshot_2019-10-19 Aufgaben - Nextcloud](https://user-images.githubusercontent.com/2496460/67149838-7a357380-f2b0-11e9-9c66-f1488bc7d462.png)
