### PR TITLE
Fixes style of italic text in markdown

### DIFF
--- a/css/src/markdown.scss
+++ b/css/src/markdown.scss
@@ -25,6 +25,10 @@
 		text-decoration: line-through;
 	}
 
+	em {
+		font-style: italic;
+	}
+
 	ol,
 	ul {
 		margin-left: 20px;


### PR DESCRIPTION
Fixes #701

Signed-off-by: Tim Hollmann <github.fe8c53c0@mail.tim-hollmann.de>