### PR TITLE
Return a moment for dates from tasks model

### DIFF
--- a/src/components/Task.vue
+++ b/src/components/Task.vue
@@ -76,8 +76,8 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 					<span :style="{'background-color': task.calendar.color}" class="calendar-indicator" />
 					<span class="calendar-name">{{ task.calendar.displayName }}</span>
 				</div>
-				<div v-if="task.due" :class="{overdue: overdue(task.due)}" class="duedate">
-					{{ task.due | formatDate }}
+				<div v-if="task.due" :class="{overdue: overdue(task.dueMoment)}" class="duedate">
+					{{ task.dueMoment | formatDate }}
 				</div>
 				<div v-if="task.pinned">
 					<span class="icon icon-bw icon-pinned" />
@@ -141,7 +141,7 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 </template>
 
 <script>
-import { overdue, valid, sort, searchSubTasks, isTaskInList } from '../store/storeHelper'
+import { overdue, sort, searchSubTasks, isTaskInList } from '../store/storeHelper'
 import ClickOutside from 'vue-click-outside'
 import { mapGetters, mapActions } from 'vuex'
 import focus from '../directives/focus'
@@ -162,8 +162,8 @@ export default {
 	},
 	filters: {
 		formatDate: function(date) {
-			return valid(date)
-				? moment(date, 'YYYYMMDDTHHmmss').calendar(null, {
+			return date.isValid()
+				? date.calendar(null, {
 					lastDay: OCA.Tasks.$t('tasks', '[Yesterday]'),
 					sameDay: OCA.Tasks.$t('tasks', '[Today]'),
 					nextDay: OCA.Tasks.$t('tasks', '[Tomorrow]'),

--- a/src/models/task.js
+++ b/src/models/task.js
@@ -87,13 +87,16 @@ export default class Task {
 		var comp = this.vtodo.getFirstPropertyValue('completed')
 		this._completed = !!comp
 		this._completedDate = comp ? comp.toJSDate() : null
+		this._completedDateMoment = moment(this._completedDate, 'YYYYMMDDTHHmmss')
 		this._status = this.vtodo.getFirstPropertyValue('status')
 		this._note = this.vtodo.getFirstPropertyValue('description') || ''
 		this._related = this.vtodo.getFirstPropertyValue('related-to') || null
 		this._hideSubtaks = +this.vtodo.getFirstPropertyValue('x-oc-hidesubtasks') || 0
 		this._hideCompletedSubtaks = +this.vtodo.getFirstPropertyValue('x-oc-hidecompletedsubtasks') || 0
 		this._start = this.vtodo.getFirstPropertyValue('dtstart')
+		this._startMoment = moment(this._start, 'YYYYMMDDTHHmmss')
 		this._due = this.vtodo.getFirstPropertyValue('due')
+		this._dueMoment = moment(this._due, 'YYYYMMDDTHHmmss')
 		var start = this.vtodo.getFirstPropertyValue('dtstart')
 		var due = this.vtodo.getFirstPropertyValue('due')
 		var d = due || start
@@ -102,7 +105,9 @@ export default class Task {
 		var categories = this.vtodo.getFirstProperty('categories')
 		this._categories = categories ? categories.getValues() : []
 		this._modified = this.vtodo.getFirstPropertyValue('last-modified')
+		this._modifiedMoment = moment(this._modified, 'YYYYMMDDTHHmmss')
 		this._created = this.vtodo.getFirstPropertyValue('created')
+		this._createdMoment = moment(this._created, 'YYYYMMDDTHHmmss')
 		this._class = this.vtodo.getFirstPropertyValue('class') || 'PUBLIC'
 		this._pinned = this.vtodo.getFirstPropertyValue('x-pinned') === 'true'
 
@@ -290,10 +295,15 @@ export default class Task {
 		var comp = this.vtodo.getFirstPropertyValue('completed')
 		this._completed = !!comp
 		this._completedDate = comp ? comp.toJSDate() : null
+		this._completedDateMoment = moment(this._completedDate, 'YYYYMMDDTHHmmss')
 	}
 
 	get completedDate() {
 		return this._completedDate
+	}
+
+	get completedDateMoment() {
+		return this._completedDateMoment.clone()
 	}
 
 	get status() {
@@ -394,6 +404,11 @@ export default class Task {
 		}
 		this.updateLastModified()
 		this._start = this.vtodo.getFirstPropertyValue('dtstart')
+		this._startMoment = moment(this._start, 'YYYYMMDDTHHmmss')
+	}
+
+	get startMoment() {
+		return this._startMoment.clone()
 	}
 
 	get due() {
@@ -408,6 +423,11 @@ export default class Task {
 		}
 		this.updateLastModified()
 		this._due = this.vtodo.getFirstPropertyValue('due')
+		this._dueMoment = moment(this._due, 'YYYYMMDDTHHmmss')
+	}
+
+	get dueMoment() {
+		return this._dueMoment.clone()
 	}
 
 	get allDay() {
@@ -487,20 +507,30 @@ export default class Task {
 		this.vtodo.updatePropertyWithValue('last-modified', now)
 		this.vtodo.updatePropertyWithValue('dtstamp', now)
 		this._modified = now
+		this._modifiedMoment = moment(this._modified, 'YYYYMMDDTHHmmss')
 	}
 
 	get modified() {
 		return this._modified
 	}
 
+	get modifiedMoment() {
+		return this._modifiedMoment.clone()
+	}
+
 	get created() {
 		return this._created
+	}
+
+	get createdMoment() {
+		return this._createdMoment.clone()
 	}
 
 	set created(createdDate) {
 		this.vtodo.updatePropertyWithValue('created', createdDate)
 		this.updateLastModified()
 		this._created = this.vtodo.getFirstPropertyValue('created')
+		this._createdMoment = moment(this._created, 'YYYYMMDDTHHmmss')
 	}
 
 	get class() {

--- a/src/store/storeHelper.js
+++ b/src/store/storeHelper.js
@@ -97,7 +97,7 @@ function isTaskPriority(task) {
  * @returns {Boolean}
  */
 function isTaskCurrent(task) {
-	return !valid(task.start) || moment(task.start, 'YYYYMMDDTHHmmss').diff(moment(), 'days', true) < 0 || moment(task.due, 'YYYYMMDDTHHmmss').diff(moment(), 'days', true) < 0
+	return !task.startMoment.isValid() || task.startMoment.diff(moment(), 'days', true) < 0 || task.dueMoment.diff(moment(), 'days', true) < 0
 }
 
 /**
@@ -107,17 +107,17 @@ function isTaskCurrent(task) {
  * @returns {Boolean}
  */
 function isTaskToday(task) {
-	return (today(task.start) || today(task.due))
+	return (today(task.startMoment) || today(task.dueMoment))
 }
 
 /**
  * Checks if a date is today
  *
- * @param {String} date The date
+ * @param {Moment} date The date as moment
  * @returns {Boolean}
  */
 function today(date) {
-	return valid(date) && moment(date, 'YYYYMMDDTHHmmss').diff(moment().startOf('day'), 'days', true) < 1
+	return date.isValid() && date.diff(moment().startOf('day'), 'days', true) < 1
 }
 
 /**
@@ -127,17 +127,17 @@ function today(date) {
  * @returns {Boolean}
  */
 function isTaskWeek(task) {
-	return (week(task.start) || week(task.due))
+	return (week(task.startMoment) || week(task.dueMoment))
 }
 
 /**
  * Checks if a date lies within the next week
  *
- * @param {String} date The date
+ * @param {Moment} date The date as moment
  * @returns {Boolean}
  */
 function week(date) {
-	return valid(date) && moment(date, 'YYYYMMDDTHHmmss').diff(moment().startOf('day'), 'days', true) < 7
+	return date.isValid() && date.diff(moment().startOf('day'), 'days', true) < 7
 }
 
 /**
@@ -155,8 +155,8 @@ function isTaskDay(task, day) {
 
 function dayOfTask(task) {
 	var diff, startdiff, duediff
-	var start = moment(task.start, 'YYYYMMDDTHHmmss').startOf('day')
-	var due = moment(task.due, 'YYYYMMDDTHHmmss').startOf('day')
+	var start = task.startMoment.startOf('day')
+	var due = task.dueMoment.startOf('day')
 
 	// Add all tasks whose start date will be reached at that day.
 	if (start.isValid() && !due.isValid()) {
@@ -181,23 +181,13 @@ function dayOfTask(task) {
 }
 
 /**
- * Checks if a date is valid
- *
- * @param {String} date The date
- * @returns {Boolean}
- */
-function valid(date) {
-	return moment(date, 'YYYYMMDDTHHmmss').isValid()
-}
-
-/**
  * Checks if a date is overdue
  *
- * @param {String} due The due date
+ * @param {Moment} date The date
  * @returns {Boolean}
  */
-function overdue(due) {
-	return valid(due) && moment(due, 'YYYYMMDDTHHmmss').diff(moment()) < 0
+function overdue(date) {
+	return date.isValid() && date.diff(moment()) < 0
 }
 
 /**
@@ -396,8 +386,7 @@ function sortByDate(taskA, taskB, date) {
 	if (taskA[date] === null && taskB[date] === null) {
 		return 0
 	}
-
-	return moment(taskA[date], 'YYYYMMDDTHHmmss').diff(moment(taskB[date], 'YYYYMMDDTHHmmss'))
+	return taskA[date + 'Moment'].diff(taskB[date + 'Moment'])
 }
 
 /**
@@ -433,7 +422,6 @@ function searchSubTasks(task, searchQuery) {
 
 export {
 	isTaskInList,
-	valid,
 	overdue,
 	isParentInList,
 	sort,

--- a/src/store/tasks.js
+++ b/src/store/tasks.js
@@ -454,9 +454,9 @@ const mutations = {
 		} else {
 			// Check, that the due date is after the start date.
 			// If it is not, shift the start date to keep the difference between start and due equal.
-			var start = moment(task.start, 'YYYY-MM-DDTHH:mm:ss')
+			var start = task.startMoment
 			if (start.isValid() && due.isBefore(start)) {
-				var currentdue = moment(task.due, 'YYYY-MM-DDTHH:mm:ss')
+				var currentdue = task.dueMoment
 				if (currentdue.isValid()) {
 					start.subtract(currentdue.diff(due), 'ms')
 				} else {
@@ -483,9 +483,9 @@ const mutations = {
 		} else {
 			// Check, that the start date is before the due date.
 			// If it is not, shift the due date to keep the difference between start and due equal.
-			var due = moment(task.due, 'YYYY-MM-DDTHH:mm:ss')
+			var due = task.dueMoment
 			if (due.isValid() && start.isAfter(due)) {
-				var currentstart = moment(task.start, 'YYYY-MM-DDTHH:mm:ss')
+				var currentstart = task.startMoment
 				if (currentstart.isValid()) {
 					due.add(start.diff(currentstart), 'ms')
 				} else {
@@ -1032,8 +1032,8 @@ const actions = {
 	 * @param {Integer} day The day to set
 	 */
 	async setDate(context, { task, day }) {
-		var start = moment(task.start, 'YYYYMMDDTHHmmss').startOf('day')
-		var due = moment(task.due, 'YYYYMMDDTHHmmss').startOf('day')
+		var start = task.startMoment.startOf('day')
+		var due = task.dueMoment.startOf('day')
 		day = moment().startOf('day').add(day, 'days')
 
 		var diff
@@ -1042,7 +1042,7 @@ const actions = {
 			diff = start.diff(moment().startOf('day'), 'days')
 			diff = diff < 0 ? 0 : diff
 			if (diff !== day) {
-				var newStart = moment(task.start, 'YYYYMMDDTHHmmss').year(day.year()).month(day.month()).date(day.date())
+				var newStart = task.startMoment.year(day.year()).month(day.month()).date(day.date())
 				context.commit('setStart', { task: task, start: newStart })
 				context.dispatch('scheduleTaskUpdate', task)
 			}
@@ -1051,7 +1051,7 @@ const actions = {
 			diff = due.diff(moment().startOf('day'), 'days')
 			diff = diff < 0 ? 0 : diff
 			if (diff !== day) {
-				var newDue = moment(task.due, 'YYYYMMDDTHHmmss').year(day.year()).month(day.month()).date(day.date())
+				var newDue = task.dueMoment.year(day.year()).month(day.month()).date(day.date())
 				context.commit('setDue', { task: task, due: newDue })
 				context.dispatch('scheduleTaskUpdate', task)
 			}


### PR DESCRIPTION
Cloning a moment is 8x faster than creating a moment from a date object. This code
```javascript
	const iterations = 1000
	const t0 = performance.now()
	for (var j = 0; j < iterations; j++) {
		var tmp = moment(task.due)
	}
	const t1 = performance.now()
	console.debug(`This took ${t1 - t0} ms.`)

	const t2 = performance.now()
	for (var j = 0; j < iterations; j++) {
		var tmp = task.dueMoment
	}
	const t3 = performance.now()
	console.debug(`This took ${t3 - t2} ms.`)
```
prints
```
    This took 116.985635 ms.
    This took 15.836432000000059 ms.
```

I don't know, if this really has a measureable effect on the App itself, but it shouldn't make it slower for sure.
