### PR TITLE
Drop support for PHP7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,9 +117,6 @@ matrix:
       after_success:
 
     - language: php
-      php: 7.1
-
-    - language: php
       php: 7.2
 
     - language: php


### PR DESCRIPTION
With https://github.com/nextcloud/server/pull/18062 support for php 7.1 was dropped in server, which breaks the tests for Tasks. This PR drops the php 7.1 test for Tasks.