### PR TITLE
Hide empty status field for read-only tasks

### DIFF
--- a/src/components/TheDetails.vue
+++ b/src/components/TheDetails.vue
@@ -215,7 +215,8 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 							</div>
 						</div>
 					</li>
-					<li class="section detail-class reactive">
+					<li v-show="!task.calendar.readOnly || task.status"
+						class="section detail-class reactive">
 						<div v-click-outside="() => finishEditing('status')"
 							class="section-content"
 							@click="editProperty('status')"


### PR DESCRIPTION
Fixes issue introduced with #655 