### PR TITLE
Correctly import uuid

### DIFF
--- a/src/models/task.js
+++ b/src/models/task.js
@@ -22,7 +22,7 @@
  *
  */
 
-import uuid from 'uuid'
+import { v4 as uuid } from 'uuid'
 import ICAL from 'ical.js'
 import PQueue from 'p-queue'
 


### PR DESCRIPTION
Since uuid 7.0.0 there is no default export anymore, so https://github.com/nextcloud/tasks/pull/890 broke creating tasks. This fixes it.