### PR TITLE
Adjust Tasks to new nextcloud/vue version

### DIFF
--- a/css/src/style.scss
+++ b/css/src/style.scss
@@ -2,7 +2,7 @@
 	* rules for app-navigation
 	*/
 
-#app-navigation {
+.app-navigation {
 	> ul {
 		> li {
 			&.collection .app-navigation-entry-icon::before {
@@ -241,15 +241,10 @@
 	text-decoration: none;
 }
 
-#content {
-	color: $gray_dark;
-}
-
-#app-content {
-	overflow-x: hidden;
-
+.app-content {
 	.header {
 		margin: 12px 0;
+		margin-left: 27px;
 		display: flex;
 
 		#add-task {
@@ -1318,7 +1313,13 @@ input[type='checkbox'].checkbox {
 }
 
 @media only screen and (max-width: $breakpoint-mobile) {
-	#app-content > div {
-		padding: 6px 0 75px;
+	.app-content {
+
+		& > div {
+			padding: 6px 0 75px;
+		}
+		.header {
+			margin-left: 44px;
+		}
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3965,32 +3965,57 @@
       }
     },
     "@nextcloud/vue": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-1.5.0.tgz",
-      "integrity": "sha512-z0KZP0PcWyHsD5zpzBJRusToGzC/1DTjapuDMrSAOSuA5lThg/Td7brmIQSwWTrw66OrL5MIRK+8HoKMWmQPAA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-2.0.0.tgz",
+      "integrity": "sha512-Y8OmsRHvskpRbfcBXUy8U6+Ctl8kyWK8qHkmsi1kWL85l0262OxcTA9BU/Qh9vAn9sqTrT7skXRAVnQckO4y0A==",
       "requires": {
-        "@nextcloud/axios": "^1.1.0",
-        "@nextcloud/l10n": "^1.1.0",
-        "@nextcloud/router": "^1.0.0",
-        "core-js": "^3.4.4",
+        "@nextcloud/auth": "^1.2.3",
+        "@nextcloud/axios": "^1.3.2",
+        "@nextcloud/event-bus": "^1.1.4",
+        "@nextcloud/l10n": "^1.2.3",
+        "@nextcloud/router": "^1.0.2",
+        "core-js": "^3.6.5",
         "debounce": "1.2.0",
-        "escape-html": "^1.0.3",
         "hammerjs": "^2.0.8",
         "md5": "^2.2.1",
-        "regenerator-runtime": "^0.13.3",
-        "v-click-outside": "^3.0.0",
-        "v-tooltip": "^2.0.0-rc.33",
-        "vue": "^2.6.7",
-        "vue-color": "^2.7.0",
-        "vue-multiselect": "^2.1.3",
+        "regenerator-runtime": "^0.13.5",
+        "v-click-outside": "^3.0.1",
+        "v-tooltip": "^2.0.3",
+        "vue": "^2.6.11",
+        "vue-color": "^2.7.1",
+        "vue-multiselect": "^2.1.6",
         "vue-visible": "^1.0.2",
-        "vue2-datepicker": "^3.3.1"
+        "vue2-datepicker": "^3.4.1"
       },
       "dependencies": {
+        "@nextcloud/auth": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-1.2.3.tgz",
+          "integrity": "sha512-SN0g1nyflt2H34zkCFflOky/h0r9DNHb7T8l/JILyFTCoL8f+f67V2Q4jLLfyapEXgq0b3xG7p8FtrBX5/JhWA==",
+          "requires": {
+            "@nextcloud/event-bus": "^1.1.3",
+            "core-js": "^3.6.4"
+          }
+        },
+        "@nextcloud/event-bus": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-1.1.4.tgz",
+          "integrity": "sha512-It27KzmUaSQ7w22nHFwOn8XgeVG0HYYOSNG9gs4UkP5VqcZ16m4ydt3GkMpWcyFec4OUjJc+yf7omRc3pNxsSw==",
+          "requires": {
+            "@types/semver": "^6.2.1",
+            "core-js": "^3.6.2",
+            "semver": "^6.3.0"
+          }
+        },
         "core-js": {
           "version": "3.6.5",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
           "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
@@ -4161,6 +4186,11 @@
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
       "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
       "dev": true
+    },
+    "@types/semver": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.1.tgz",
+      "integrity": "sha512-+beqKQOh9PYxuHvijhVl+tIHvT6tuwOrE9m14zd+MT2A38KoKZhh7pYJ0SNleLtwDsiIxHDsIk9bv01oOxvSvA=="
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -7741,11 +7771,6 @@
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
       "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==",
       "dev": true
-    },
-    "escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -22353,9 +22378,9 @@
       "integrity": "sha512-yaX2its9XAJKGuQqf7LsiZHHSkxsIK8rmCOQOvEGEoF41blKRK8qr9my4qYoD6ikdLss4n8tKqYBecmaY0+WJg=="
     },
     "vue2-datepicker": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/vue2-datepicker/-/vue2-datepicker-3.4.1.tgz",
-      "integrity": "sha512-gCPZAwIyPLeN1P3xDg/Oj/UyQTIqnoFFzXw+yfvmUDxL430u/rHq1/JqFSGISEhTvJJu0brgHHrop3A7VBW6rA==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/vue2-datepicker/-/vue2-datepicker-3.5.0.tgz",
+      "integrity": "sha512-E52TUjf57Qj2ZWtwtplS+BtYfz8wQFHnjux0q2X8N+ENvL3rHjp9pwEs0ukT1rDTouLdPtvACaXXLfDEy39mlw==",
       "requires": {
         "date-fns": "^2.0.1",
         "date-format-parse": "^0.2.5"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"@nextcloud/initial-state": "1.1.2",
 		"@nextcloud/moment": "^1.1.1",
 		"@nextcloud/router": "^1.0.2",
-		"@nextcloud/vue": "^1.5.0",
+		"@nextcloud/vue": "^2.0.0",
 		"@vue/test-utils": "^1.0.0-beta.33",
 		"cdav-library": "github:nextcloud/cdav-library",
 		"color-convert": "^2.0.1",

--- a/src/App.vue
+++ b/src/App.vue
@@ -20,7 +20,7 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <template>
-	<div id="content" class="app-tasks" @click="closeDetails($event)">
+	<Content app-name="tasks" @click="closeDetails($event)">
 		<AppNavigation>
 			<TheList />
 			<AppNavigationSettings>
@@ -32,16 +32,17 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 			<RouterView />
 		</AppContent>
 
-		<div id="app-sidebar" :class="{disappear: $route.params.taskId === undefined}">
+		<div class="app-sidebar" :class="{disappear: $route.params.taskId === undefined}">
 			<RouterView name="details" />
 		</div>
-	</div>
+	</Content>
 </template>
 
 <script>
 import { mapState } from 'vuex'
 import AppNavigation from '@nextcloud/vue/dist/Components/AppNavigation'
 import AppContent from '@nextcloud/vue/dist/Components/AppContent'
+import Content from '@nextcloud/vue/dist/Components/Content'
 import AppNavigationSettings from '@nextcloud/vue/dist/Components/AppNavigationSettings'
 import TheList from './components/AppNavigation/List'
 import TheSettings from './components/AppNavigation/TheSettings'
@@ -55,6 +56,7 @@ export default {
 		AppNavigation,
 		AppContent,
 		AppNavigationSettings,
+		Content,
 	},
 	computed: {
 		...mapState({


### PR DESCRIPTION
This PR adjusts the app to nextcloud/vue@2.0.0.

![tasks_vue](https://user-images.githubusercontent.com/2496460/80715922-5670a700-8af7-11ea-99bc-839a6f568925.gif)

@skjnldsv @jancborchardt @ma12-co On small screens the main content is not shifted to the right anymore when the app-navigation is opened, so the app-navigation overlaps the content until you close it. Is this the new desired behaviour (I am ok with it, just asking to make sure nothing from Tasks is interfering with the new version)?

Edit: Just saw the answer in https://github.com/nextcloud/nextcloud-vue/pull/989:
>   * [x]  In mobile, opening the navigation does NOT shift the content, it just hovers it now. It avoid changing the whole layout and improve the rendering performances

But it might be nice to close the app-navigation on mobile when clicking outside of it, wouldn't it? Otherwise you have to manually close it again before you can access the content again.