### PR TITLE
Remember last route

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -25,6 +25,6 @@ return [
 		['name' => 'collections#getCollections','url' => '/collections',										'verb' => 'GET'],
 		['name' => 'collections#setVisibility',	'url' => '/collection/{collectionID}/visibility/{visibility}',	'verb' => 'POST'],
 		['name' => 'settings#get',				'url' => '/settings',											'verb' => 'GET'],
-		['name' => 'settings#set',				'url' => '/settings/{setting}/{value}',							'verb' => 'POST'],
+		['name' => 'settings#set',				'url' => '/settings/{setting}',									'verb' => 'POST'],
 	]
 ];

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -63,13 +63,15 @@ class SettingsService {
 		$sortOrder = (string)$this->config->getUserValue($this->userId, $this->appName, 'various_sortOrder', 'default');
 		$sortDirection = (bool)$this->config->getUserValue($this->userId, $this->appName, 'various_sortDirection', false);
 		$allDay = (bool)$this->config->getUserValue($this->userId, $this->appName, 'various_allDay', false);
+		$initialRoute = (string)$this->config->getUserValue($this->userId, $this->appName, 'various_initialRoute', '/collections/all');
 
 		return [
 			'defaultCalendarId' => $defaultCalendarId,
 			'showHidden' => $showHidden,
 			'sortOrder' => $sortOrder,
 			'sortDirection' => $sortDirection,
-			'allDay' => $allDay
+			'allDay' => $allDay,
+			'initialRoute' => $initialRoute
 		];
 	}
 

--- a/src/components/AppNavigation/List.vue
+++ b/src/components/AppNavigation/List.vue
@@ -36,7 +36,8 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 			@drop.native="dropTaskOnCollection(...arguments, collection)"
 			@dragover.native="dragOver"
 			@dragenter.native="dragEnter(...arguments, collection)"
-			@dragleave.native="dragLeave">
+			@dragleave.native="dragLeave"
+			@click="setInitialRoute(`/collections/${collection.id}`)">
 			<AppNavigationCounter slot="counter">
 				{{ collectionCount(collection.id) | counterFormatter }}
 			</AppNavigationCounter>
@@ -44,7 +45,8 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 		<ListItemCalendar
 			v-for="calendar in calendars"
 			:key="calendar.id"
-			:calendar="calendar" />
+			:calendar="calendar"
+			@click.native="setInitialRoute(`/calendars/${calendar.id}`)" />
 		<AppNavigationItem v-click-outside="cancelCreate"
 			:title="$t('tasks', 'Add List…')"
 			icon="sprt-add"
@@ -144,6 +146,7 @@ export default {
 			'setPriority',
 			'setPercentComplete',
 			'setDate',
+			'setSetting',
 		]),
 
 		/**
@@ -316,6 +319,14 @@ export default {
 		},
 		setColor(color) {
 			this.selectedColor = color
+		},
+		/**
+		 * Saves the current route as new initial route
+		 *
+		 * @param {String} route The new initial route
+		 */
+		setInitialRoute(route) {
+			this.setSetting({ type: 'initialRoute', value: route })
 		},
 	},
 }

--- a/src/router.js
+++ b/src/router.js
@@ -19,18 +19,19 @@
  *
  */
 
-import Vue from 'vue'
-import VueRouter from 'vue-router'
-
+import { getInitialRoute } from './utils/router.js'
 import Collections from './components/TheCollections/Collections'
 import Calendar from './components/TheCollections/Calendar'
 import TheDetails from './components/TheDetails'
+
+import Vue from 'vue'
+import VueRouter from 'vue-router'
 
 const routes = [
 	// using
 	// { path: '/collections/all', component: CollectionGeneral, alias: '/' },
 	// instead of
-	{ path: '/', redirect: '/collections/all' },
+	{ path: '/', redirect: getInitialRoute() },
 	// would also be an option, but it currently does not work
 	// reliably with router-link due to
 	// https://github.com/vuejs/vue-router/issues/419

--- a/src/store/settings.js
+++ b/src/store/settings.js
@@ -93,7 +93,7 @@ const actions = {
 	setSetting(context, payload) {
 		context.commit('setSetting', payload)
 		return new Promise(function() {
-			Requests.post(generateUrl('apps/tasks/settings/{type}/{value}', payload), {})
+			Requests.post(generateUrl('apps/tasks/settings/{type}', payload), { value: payload.value })
 		})
 	},
 

--- a/src/utils/router.js
+++ b/src/utils/router.js
@@ -1,0 +1,39 @@
+/**
+ * Nextcloud - Tasks
+ *
+ * @author Georg Ehrke <oc.list@georgehrke.com>
+ * @copyright Copyright (c) 2020 Georg Ehrke
+ *
+ * @author Raimund Schlüßler
+ * @copyright 2020 Raimund Schlüßler <raimund.schluessler@mailbox.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+import { loadState } from '@nextcloud/initial-state'
+
+/**
+ * Gets the initial route
+ *
+ * @returns {String}
+ */
+export function getInitialRoute() {
+	try {
+		return loadState('tasks', 'initialRoute')
+	} catch (error) {
+		return '/collections/all'
+	}
+}

--- a/tests/php/unit/Service/SettingsServiceTest.php
+++ b/tests/php/unit/Service/SettingsServiceTest.php
@@ -55,7 +55,8 @@ class SettingsServiceTest extends TestCase {
 			'showHidden' => false,
 			'sortOrder' => 'default',
 			'sortDirection' => false,
-			'allDay' => false
+			'allDay' => false,
+			'initialRoute' => '/collections/all'
 		];
 
 		$map = [
@@ -93,6 +94,13 @@ class SettingsServiceTest extends TestCase {
 				'various_allDay',
 				false,
 				false
+			],
+			[
+				$this->userId,
+				$this->appName,
+				'various_initialRoute',
+				'/collections/all',
+				'/collections/all'
 			]
 		];
 


### PR DESCRIPTION
We load the last view now when the app is intially opened.
Clicking on a collection or calendar in the left sidebar saves this route to the server and we redirect to this route on app load.

![initialRoute](https://user-images.githubusercontent.com/2496460/80534353-5eb5ce80-899f-11ea-9fe6-27d13a3e6346.gif)


@jancborchardt @jakobroehrl You might want to have a look.

Closes #80.