### PR TITLE
Also show due time in task body on large screens

### DIFF
--- a/css/src/style.scss
+++ b/css/src/style.scss
@@ -600,7 +600,29 @@
 									text-align: right;
 									text-overflow: ellipsis;
 									white-space: nowrap;
+								}
+
+								&__short {
 									width: 60px;
+								}
+
+								&__long {
+									width: 100px;
+									display: none;
+
+									&--date-only {
+										width: 60px;
+									}
+								}
+
+								@media only screen and (min-width: $breakpoint-mobile) {
+									&__long {
+										display: inline-block;
+									}
+
+									&__short {
+										display: none;
+									}
 								}
 							}
 

--- a/src/components/TaskBody.vue
+++ b/src/components/TaskBody.vue
@@ -83,7 +83,8 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 					<span class="icon icon-sprt-bw sprt-note" />
 				</div>
 				<div v-if="task.due" :class="{overdue: overdue(task.dueMoment)}" class="duedate">
-					<span>{{ dueDateString }}</span>
+					<span class="duedate__short">{{ dueDateShort }}</span>
+					<span class="duedate__long" :class="{ 'duedate__long--date-only': task.allDay }">{{ dueDateLong }}</span>
 				</div>
 				<Actions v-if="!deleteTimeout" class="reactive no-nav" menu-align="right">
 					<ActionButton v-if="!task.calendar.readOnly"
@@ -207,7 +208,7 @@ export default {
 			searchQuery: 'searchQuery',
 		}),
 
-		dueDateString() {
+		dueDateShort() {
 			return this.task.dueMoment.isValid()
 				? this.task.dueMoment.calendar(null, {
 					lastDay: this.$t('tasks', '[Yesterday]'),
@@ -216,6 +217,22 @@ export default {
 					lastWeek: 'L',
 					nextWeek: 'L',
 					sameElse: 'L',
+				})
+				: ''
+		},
+
+		dueDateLong() {
+			if (this.task.allDay) {
+				return this.dueDateShort
+			}
+			return this.task.dueMoment.isValid()
+				? this.task.dueMoment.calendar(null, {
+					lastDay: this.$t('tasks', '[Yesterday at] LT'),
+					sameDay: this.$t('tasks', '[Today at] LT'),
+					nextDay: this.$t('tasks', '[Tomorrow at] LT'),
+					lastWeek: this.$t('tasks', 'L [at] LT'),
+					nextWeek: this.$t('tasks', 'L [at] LT'),
+					sameElse: this.$t('tasks', 'L [at] LT'),
 				})
 				: ''
 		},


### PR DESCRIPTION
On large screens we also show the due time in the task body.

![duetime](https://user-images.githubusercontent.com/2496460/80641939-eb2ac480-8a65-11ea-99e5-aab55b1bbb0c.gif)

Closes #914.

@GambaJo @zeroepix Please have a look.