### PR TITLE
Fix the sidebar

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -32,7 +32,7 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 			<RouterView />
 		</AppContent>
 
-		<div class="app-sidebar" :class="{disappear: $route.params.taskId === undefined}">
+		<div id="app-sidebar" :class="{disappear: $route.params.taskId === undefined}">
 			<RouterView name="details" />
 		</div>
 	</Content>


### PR DESCRIPTION
Since the sidebar doesn't use the vue-component yet, we cannot use `class="app-sidebar"` and have to stick to the server styles. Fixup of #965.