### PR TITLE
Show calendar color in task list

### DIFF
--- a/css/src/style.scss
+++ b/css/src/style.scss
@@ -652,23 +652,38 @@
 		}
 	}
 
-	h2 {
-		font-weight: bold;
-		font-size: 13px;
+	.heading {
+		display: flex;
+		align-items: center;
 		margin-bottom: 10px;
 		margin-top: 20px !important;
-		word-wrap: break-word;
-		opacity: .5;
 
-		&:hover {
-			opacity: .7;
+		&--hiddentasks {
+			.heading__title {
+				display: inline-block;
+				padding-right: 16px;
+				background-position: right center;
+				cursor: pointer;
+				&:hover {
+					opacity: .7;
+				}
+			}
 		}
 
-		&.heading-hiddentasks {
-			display: inline-block;
-			padding-right: 16px;
-			background-position: right center;
-			cursor: pointer;
+		&__title {
+			font-weight: bold;
+			font-size: 13px;
+			word-wrap: break-word;
+			opacity: .5;
+
+		}
+
+		&__icon-bullet {
+			width: 14px;
+			height: 14px;
+			border: none;
+			border-radius: 50%;
+			margin-right: 5px;
 		}
 	}
 }

--- a/src/components/TheCollections/Calendar.vue
+++ b/src/components/TheCollections/Calendar.vue
@@ -49,8 +49,8 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 						:key="task.key"
 						:task="task" />
 				</TaskDragContainer>
-				<h2 v-show="completedCount(calendarId)" class="heading-hiddentasks icon-triangle-s reactive" @click="toggleHidden">
-					{{ completedCountString }}
+				<h2 v-show="completedCount(calendarId)" class="heading heading--hiddentasks reactive" @click="toggleHidden">
+					<span class="heading__title icon-triangle-s">{{ completedCountString }}</span>
 				</h2>
 				<TaskDragContainer v-if="showHidden"
 					:calendar-id="calendarId"

--- a/src/components/TheCollections/General.vue
+++ b/src/components/TheCollections/General.vue
@@ -42,7 +42,8 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 				:rel="calendar.id"
 				class="grouped-tasks ui-droppable">
 				<h2 class="heading">
-					{{ calendar.displayName }}
+					<span class="heading__icon-bullet" :style="{'background-color': calendar.color }" />
+					<span class="heading__title">{{ calendar.displayName }}</span>
 				</h2>
 				<TaskDragContainer
 					:calendar-id="calendar.id"

--- a/src/components/TheCollections/Week.vue
+++ b/src/components/TheCollections/Week.vue
@@ -42,7 +42,7 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 				:day="day.diff"
 				class="grouped-tasks ui-droppable">
 				<h2 class="heading">
-					{{ dayString(day.diff) }}
+					<span class="heading__title">{{ dayString(day.diff) }}</span>
 				</h2>
 				<TaskDragContainer
 					:collection-id="'week-' + day.diff"


### PR DESCRIPTION
Shows the calendar color next to the calendar name in the task list, closes #1012.

![Screenshot_2020-05-08 Tasks - Nextcloud](https://user-images.githubusercontent.com/2496460/81440052-b60e2880-916f-11ea-8538-df0f6392afad.png)
