### PR TITLE
Adjust task-body background-color to new scheme

### DIFF
--- a/css/src/style.scss
+++ b/css/src/style.scss
@@ -461,10 +461,12 @@
 						position: relative;
 						border: 1px solid $gray_light;
 
-						&:hover,
+						&:hover {
+							background-color: var(--color-background-hover);
+						}
+
 						&.active {
-							background-color: $gray_easy;
-							box-shadow: inset 4px 0 var(--color-primary);
+							background-color: var(--color-primary-light) !important;
 						}
 
 						.task-checkbox {


### PR DESCRIPTION
As discussed in https://github.com/nextcloud/tasks/issues/1012#issuecomment-626052255 this PR adjusts the task-body background-color on active and hover to comply with the new scheme e.g. used in nextcloud-vue.

Before (second task is hovered, first one active/opened):
![Screenshot_2020-05-09 Tasks - Nextcloud(1)](https://user-images.githubusercontent.com/2496460/81483071-aeb45100-923b-11ea-8654-1009b6e5d84a.png)

After (second task is hovered, first one active/opened):
![Screenshot_2020-05-09 Tasks - Nextcloud](https://user-images.githubusercontent.com/2496460/81483050-9cd2ae00-923b-11ea-8a19-60ffa5730deb.png)

@jancborchardt @javisomoza I would be open to replace the color used on active (`var(--color-primary-light)`) with the calendar color, but I have no idea how to get a 10% transparent color and apply it to the hover selector with javascript.
