### PR TITLE
Make task input field sticky

### DIFF
--- a/css/src/style.scss
+++ b/css/src/style.scss
@@ -249,8 +249,11 @@ $blue_due: #4271a6;			// due dates and low importance
 
 .app-content {
 	.header {
-		margin: 12px 0;
-		margin-left: 27px;
+		padding: 12px 12px 12px 44px;
+		position: sticky;
+		top: 50px;
+		background-color: var(--color-main-background-translucent);
+		z-index: 1000;
 		display: flex;
 
 		#add-task {
@@ -381,13 +384,16 @@ $blue_due: #4271a6;			// due dates and low importance
 	}
 
 	> div {
-		padding: 6px 17px 75px;
 		box-sizing: border-box;
-		height: 100%;
-		overflow: hidden;
+		padding-bottom: 75px;
 
 		.task-list {
 			width: 100%;
+			padding: 0 12px;
+
+			@media only screen and (max-width: $breakpoint-mobile) {
+				padding: 0;
+			}
 
 			.loadmore {
 				font-size: 11px;
@@ -1354,17 +1360,5 @@ input[type='checkbox'].checkbox {
 		width: 80%;
 		margin: auto;
 		padding-top: 10px;
-	}
-}
-
-@media only screen and (max-width: $breakpoint-mobile) {
-	.app-content {
-
-		& > div {
-			padding: 6px 0 75px;
-		}
-		.header {
-			margin-left: 44px;
-		}
 	}
 }


### PR DESCRIPTION
This PR makes the task input field and the sort-order dropdown stick to the top of the page, so you can always create new tasks without scrolling to the top first.

Before:
![not_sticky](https://user-images.githubusercontent.com/2496460/81561136-fd283380-9392-11ea-9f96-ca527a4b28d2.gif)

After:
![sticky](https://user-images.githubusercontent.com/2496460/81561150-01545100-9393-11ea-868c-0d518f4d287e.gif)

Closes #1026.