### PR TITLE
Removing the import of the vars file

### DIFF
--- a/css/tasks.scss
+++ b/css/tasks.scss
@@ -19,7 +19,6 @@
  *
  */
 
-@import './src/vars';
 @import './src/sprites-color';
 @import './src/sprites-bw';
 @import './src/style';


### PR DESCRIPTION
I could be wrong but it seems like the vars file have been removed from the project since the 190bb435fd3425bacb9f15b4e44e788bd18cc64f commit