### PR TITLE
Update the design of the task list

### DIFF
--- a/css/src/style.scss
+++ b/css/src/style.scss
@@ -251,8 +251,8 @@ $priority_colors: ($red_overdue, $red_overdue, $red_overdue, $red_overdue, $yell
 }
 
 .app-content {
-	background-color: var(--color-background-dark) !important;	
-	
+	background-color: var(--color-background-dark) !important;
+
 	.header {
 		padding: 12px 15px 12px 44px;
 		position: sticky;
@@ -268,8 +268,8 @@ $priority_colors: ($red_overdue, $red_overdue, $red_overdue, $red_overdue, $yell
 		.add-task {
 			position: relative;
 			width: calc(100% - 44px);
-			
-			input{
+
+			input {
 				box-shadow: 1px 1px 1px var(--color-box-shadow);
 			}
 		}
@@ -435,13 +435,13 @@ $priority_colors: ($red_overdue, $red_overdue, $red_overdue, $red_overdue, $yell
 			CSS has no selector for this, this is done using a recursive mixin for up to 8 sublevels of tasks (arbitrary chosen).
 			After this point, the last task of the tree will have squared corners, but nothing will technically break.
 			*/
-			
+
 			@mixin remove-last-squared-corners($sublevels-left: 8) {
-				&>.add-task{
-					&::before{
+				&>.add-task {
+					&::before {
 						display: block;
 					}
-					&::after{
+					&::after {
 						display: none;
 					}
 				}
@@ -450,36 +450,36 @@ $priority_colors: ($red_overdue, $red_overdue, $red_overdue, $red_overdue, $yell
 					display: none !important;
 				}
 				@if $sublevels-left > 0 {
-					&>ol>.task-item:last-child>.subtasks-container{
+					&>ol>.task-item:last-child>.subtasks-container {
 						@include remove-last-squared-corners($sublevels-left - 1);
 					}
 				}
 			}
-			
+
 			.grouped-tasks,
 			.sortable-ghost>.subtasks-container {
 				@include remove-last-squared-corners;
 			}
-			
+
 			.grouped-tasks {
 				position: relative;
 				padding-top: 2px;
-				
+
 				>ol {
 					filter: drop-shadow(1px 1px 1px var(--color-box-shadow));
 					z-index: 1;
-					
+
 					&:hover {
 						z-index: 10;
 					}
 				}
-				
+
 				.task-item {
 					cursor: default;
 					list-style: none outside none;
 
 					&.done .task-body {
-						.task-info{
+						.task-info {
 							opacity: .6;
 						}
 
@@ -492,22 +492,22 @@ $priority_colors: ($red_overdue, $red_overdue, $red_overdue, $red_overdue, $yell
 						opacity: .6;
 					}
 
-					&.sortable-ghost {						
+					&.sortable-ghost {
 						filter: drop-shadow(0 0 3px var(--color-primary));
 						z-index: 5;
 					}
-					
+
 					&.subtasksHidden>.subtasks-container {
 						margin-left: 44px;
 					}
-					&:not(.subtasksHidden)>.subtasks-container{
+					&:not(.subtasksHidden)>.subtasks-container {
 						&>ol:not(:empty),
 						&>.add-task + ol,
 						&>.add-task {
 							margin-left: 44px;
 						}
 					}
-					
+
 					&.subtasksHidden>.subtasks-container::before,
 					&.subtasksHidden>.subtasks-container>.add-task::before,
 					&.subtasksHidden>.subtasks-container>.add-task::after,
@@ -523,10 +523,10 @@ $priority_colors: ($red_overdue, $red_overdue, $red_overdue, $red_overdue, $yell
 						position: relative;
 						z-index: -1;
 					}
-					&.subtasksHidden>.subtasks-container>.add-task::before{
+					&.subtasksHidden>.subtasks-container>.add-task::before {
 						display: none;
 					}
-					
+
 					// Apply colors to checkboxes for each non-zero priority level
 					@for $i from 1 through 9 {
 						&[data-priority="#{$i}"]>.task-body>.task-checkbox>input[type='checkbox'].checkbox + label::before {
@@ -554,7 +554,7 @@ $priority_colors: ($red_overdue, $red_overdue, $red_overdue, $red_overdue, $yell
 							padding: 12px 10px;
 							height: 44px;
 							width: 44px;
-														
+
 							input[type='checkbox'].checkbox + label::before {
 								border-width: 2px;
 								border-radius: var(--border-radius);

--- a/css/src/style.scss
+++ b/css/src/style.scss
@@ -549,11 +549,17 @@ $blue_due: #4271a6;			// due dates and low importance
 								&::before {
 									border-width: 2px;
 									border-radius: var(--border-radius);
+									border-color: var(--color-border-dark);
+								}
+
+								&:hover {
+									border-color: var(--color-border-dark);
 								}
 
 								&.priority-high::before {
 									border-color: $red_overdue;
 								}
+
 								&.priority-medium::before {
 									border-color: $yellow;
 								}
@@ -877,11 +883,17 @@ $blue_due: #4271a6;			// due dates and low importance
 					&::before {
 						border-width: 2px;
 						border-radius: var(--border-radius);
+						border-color: var(--color-border-dark);
+					}
+
+					&:hover {
+						border-color: var(--color-border-dark);
 					}
 
 					&.priority-high::before {
 						border-color: $red_overdue;
 					}
+
 					&.priority-medium::before {
 						border-color: $yellow;
 					}

--- a/css/src/style.scss
+++ b/css/src/style.scss
@@ -267,7 +267,7 @@ $blue_due: #4271a6;			// due dates and low importance
 			width: calc(100% - 44px);
 
 			input {
-				box-shadow: 1px 1px 1px var(--color-box-shadow);
+				box-shadow: 0 0 1px var(--color-box-shadow);
 			}
 		}
 
@@ -463,7 +463,7 @@ $blue_due: #4271a6;			// due dates and low importance
 				padding-top: 2px;
 
 				>ol {
-					filter: drop-shadow(1px 1px 1px var(--color-box-shadow));
+					filter: drop-shadow(0 0 1px var(--color-box-shadow));
 					z-index: 1;
 
 					&:hover {

--- a/css/src/style.scss
+++ b/css/src/style.scss
@@ -844,7 +844,7 @@ $blue_due: #4271a6;			// due dates and low importance
 			flex: 0 0 auto;
 			display: flex;
 			align-items: center;
-			background-color: var(--color-background-dark);
+			background-color: var(--color-background-hover);
 			border-bottom: 1px solid var(--color-border-dark);
 			font-size: 16px;
 			font-weight: bold;

--- a/css/src/style.scss
+++ b/css/src/style.scss
@@ -437,18 +437,19 @@ $priority_colors: ($red_overdue, $red_overdue, $red_overdue, $red_overdue, $yell
 			*/
 			
 			@mixin remove-last-squared-corners($sublevels-left: 8) {
-				&:empty {
+				&::before,
+				&>ol:empty::before {
 					display: none !important;
 				}
 				@if $sublevels-left > 0 {
-					&>.task-item:last-child>.subtasks-container>ol {
+					&>ol>.task-item:last-child>.subtasks-container{
 						@include remove-last-squared-corners($sublevels-left - 1);
 					}
 				}
 			}
 			
-			.grouped-tasks>ol,
-			.sortable-ghost>.subtasks-container>ol {
+			.grouped-tasks,
+			.sortable-ghost>.subtasks-container {
 				@include remove-last-squared-corners;
 			}
 			
@@ -487,35 +488,30 @@ $priority_colors: ($red_overdue, $red_overdue, $red_overdue, $red_overdue, $yell
 						}
 					}
 					
-					.subtasks-container>ol,
-					.subtasks-container>.add-task {
-						&:not(:empty) {
-							margin-left: 44px;
-							
-							&>.task-item:first-child>.task-body{
-								border-top-left-radius: 0;
-							}						
-						}
-
-						&::before {
-							content: '';
-							display: block;
-							height: 1px;
-							border: 0 solid var(--color-main-background);
-							border-width: var(--border-radius) 0;
-							margin: calc(-1 * var(--border-radius)) 0;
-							background-color: var(--color-background-darker);
-							position: relative;
-							z-index: -1;
-						}
-					}
-					
-					.subtasks-container>.add-task {
-						border-top: 1px solid var(--color-background-darker);
-					}
-					
-					.subtasks-container>.add-task + ol {
+					&.subtasksHidden>.subtasks-container {
 						margin-left: 44px;
+					}
+					&:not(.subtasksHidden)>.subtasks-container{
+						&>ol:not(:empty),
+						&>.add-task + ol,
+						&>.add-task {
+							margin-left: 44px;
+						}
+					}
+					
+					&.subtasksHidden>.subtasks-container::before,
+					&.subtasksHidden>.subtasks-container>.add-task::after,
+					&:not(.subtasksHidden)>.subtasks-container>.add-task::before,
+					&>.subtasks-container>ol::before {
+						content: '';
+						display: block;
+						height: 1px;
+						border: 0 solid var(--color-main-background);
+						border-width: var(--border-radius) 0;
+						margin: calc(-1 * var(--border-radius)) 0;
+						background-color: var(--color-background-darker);
+						position: relative;
+						z-index: -1;
 					}
 					
 					// Apply colors to checkboxes for each non-zero priority level

--- a/css/src/style.scss
+++ b/css/src/style.scss
@@ -467,6 +467,11 @@ $priority_colors: ($red_overdue, $red_overdue, $red_overdue, $red_overdue, $yell
 				
 				>ol {
 					filter: drop-shadow(1px 1px 1px var(--color-box-shadow));
+					z-index: 1;
+					
+					&:hover {
+						z-index: 10;
+					}
 				}
 				
 				.task-item {

--- a/css/src/style.scss
+++ b/css/src/style.scss
@@ -5,6 +5,9 @@ $red_overdue: #b3312d;		// overdue dates and high importance
 $yellow: #fd0;				// medium importance
 $blue_due: #4271a6;			// due dates and low importance
 
+// Specify colors for each non-zero priority level
+$priority_colors: ($red_overdue, $red_overdue, $red_overdue, $red_overdue, $yellow, $blue_due, $blue_due, $blue_due, $blue_due);
+
 /**
  * rules for app-navigation
  */
@@ -248,11 +251,13 @@ $blue_due: #4271a6;			// due dates and low importance
 }
 
 .app-content {
+	background-color: var(--color-background-dark) !important;	
+	
 	.header {
 		padding: 12px 15px 12px 44px;
 		position: sticky;
 		top: 50px;
-		background-color: var(--color-main-background-translucent);
+		background-color: var(--color-background-dark);
 		z-index: 1000;
 		display: flex;
 
@@ -263,6 +268,10 @@ $blue_due: #4271a6;			// due dates and low importance
 		.add-task {
 			position: relative;
 			width: calc(100% - 44px);
+			
+			input{
+				box-shadow: 1px 1px 1px var(--color-box-shadow);
+			}
 		}
 
 		.sortorder {
@@ -372,26 +381,21 @@ $blue_due: #4271a6;			// due dates and low importance
 		}
 	}
 
-	.add-task {
-		border: 1px solid var(--color-border-dark);
-
-		input {
-			border: medium none !important;
-			border-radius: 0 !important;
-			box-shadow: none !important;
-			box-sizing: border-box;
-			color: var(--color-main-text);
-			cursor: text;
-			font-size: 100%;
-			margin: 0;
-			padding: 0 15px;
-			width: 100%;
-			min-height: 44px;
-			overflow: hidden;
-			white-space: nowrap;
-			text-overflow: ellipsis;
-			outline: none;
-		}
+	.add-task input {
+		border: medium none !important;
+		box-sizing: border-box;
+		color: var(--color-main-text);
+		cursor: text;
+		font-size: 100%;
+		margin: 0;
+		padding: 0 15px;
+		width: 100%;
+		min-height: 44px;
+		overflow: hidden;
+		white-space: nowrap;
+		text-overflow: ellipsis;
+		outline: none;
+		border-radius: var(--border-radius);
 	}
 
 	> div {
@@ -414,8 +418,8 @@ $blue_due: #4271a6;			// due dates and low importance
 
 				span {
 					color: var(--color-text-lighter);
-					background-color: var(--color-background-dark);
-					border-radius: 10px;
+					background-color: var(--color-main-background);
+					border-radius: var(--border-radius-pill);
 					padding: 3px 6px;
 
 					&:hover {
@@ -425,17 +429,45 @@ $blue_due: #4271a6;			// due dates and low importance
 				}
 			}
 
+
+			/*
+			This mixin is a way to remove the squared corners from the last task of a tree.
+			CSS has no selector for this, this is done using a recursive mixin for up to 8 sublevels of tasks (arbitrary chosen).
+			After this point, the last task of the tree will have squared corners, but nothing will technically break.
+			*/
+			
+			@mixin remove-last-squared-corners($sublevels-left: 8) {
+				&:empty {
+					display: none !important;
+				}
+				@if $sublevels-left > 0 {
+					&>.task-item:last-child>.subtasks-container>ol {
+						@include remove-last-squared-corners($sublevels-left - 1);
+					}
+				}
+			}
+			
+			.grouped-tasks>ol,
+			.sortable-ghost>.subtasks-container>ol {
+				@include remove-last-squared-corners;
+			}
+			
 			.grouped-tasks {
 				position: relative;
 				padding-top: 2px;
-
+				
+				>ol {
+					filter: drop-shadow(1px 1px 1px var(--color-box-shadow));
+				}
+				
 				.task-item {
 					cursor: default;
 					list-style: none outside none;
-					margin-top: -1px;
 
 					&.done .task-body {
-						opacity: .6;
+						.task-info{
+							opacity: .6;
+						}
 
 						.title {
 							text-decoration: line-through;
@@ -446,13 +478,49 @@ $blue_due: #4271a6;			// due dates and low importance
 						opacity: .6;
 					}
 
-					&.sortable-ghost .task-body {
-						// background-color: rgba( $color-primary, .1 ); didn't work for some reason
-						background-color: transparentize( $color-primary, .9 );
-					}
+					&.sortable-ghost {						
+						filter: drop-shadow(0 0 3px var(--color-primary));
+						z-index: 5;
 
-					.subtasks-container {
+						.task-body {
+							border-radius: var(--border-radius) !important;
+						}
+					}
+					
+					.subtasks-container>ol,
+					.subtasks-container>.add-task {
+						&:not(:empty) {
+							margin-left: 44px;
+							
+							&>.task-item:first-child>.task-body{
+								border-top-left-radius: 0;
+							}						
+						}
+
+						&::before {
+							content: '';
+							display: block;
+							padding: var(--border-radius);
+							margin: calc(-1 * var(--border-radius)) 0;
+							background: var(--color-main-background);
+							position: relative;
+							z-index: -1;
+						}
+					}
+					
+					.subtasks-container>.add-task {
+						border-top: 1px solid var(--color-background-darker);
+					}
+					
+					.subtasks-container>.add-task + ol {
 						margin-left: 44px;
+					}
+					
+					// Apply colors to checkboxes for each non-zero priority level
+					@for $i from 1 through 9 {
+						&[data-priority="#{$i}"]>.task-body>.task-checkbox>input[type='checkbox'].checkbox + label::before {
+							border-color: nth($priority_colors, $i);
+						}
 					}
 
 					.task-body {
@@ -462,21 +530,26 @@ $blue_due: #4271a6;			// due dates and low importance
 						align-items: center;
 						height: 44px;
 						position: relative;
-						border: 1px solid var(--color-border-dark);
-
-						&:hover {
-							background-color: var(--color-background-hover);
-						}
+						background-color: var(--color-main-background);
+						border-radius: var(--border-radius);
+						box-shadow: inset 0 2px 0 -1px var(--color-background-darker);
 
 						&.active {
-							background-color: var(--color-primary-light) !important;
+							.task-info .title {
+								font-weight: bold;
+							}
 						}
 
 						.task-checkbox {
-							padding: 11px;
+							padding: 12px 10px;
 							height: 44px;
 							width: 44px;
-							opacity: .5;
+														
+							input[type='checkbox'].checkbox + label::before {
+								border-width: 2px;
+								border-radius: var(--border-radius);
+								border-color: $color-lightgrey;
+							}
 						}
 
 						.task-info {

--- a/css/src/style.scss
+++ b/css/src/style.scss
@@ -5,9 +5,6 @@ $red_overdue: #b3312d;		// overdue dates and high importance
 $yellow: #fd0;				// medium importance
 $blue_due: #4271a6;			// due dates and low importance
 
-// Specify colors for each non-zero priority level
-$priority_colors: ($red_overdue, $red_overdue, $red_overdue, $red_overdue, $yellow, $blue_due, $blue_due, $blue_due, $blue_due);
-
 /**
  * rules for app-navigation
  */
@@ -527,13 +524,6 @@ $priority_colors: ($red_overdue, $red_overdue, $red_overdue, $red_overdue, $yell
 						display: none;
 					}
 
-					// Apply colors to checkboxes for each non-zero priority level
-					@for $i from 1 through 9 {
-						&[data-priority="#{$i}"]>.task-body>.task-checkbox>input[type='checkbox'].checkbox + label::before {
-							border-color: nth($priority_colors, $i);
-						}
-					}
-
 					.task-body {
 						display: flex;
 						flex-direction: row;
@@ -555,10 +545,22 @@ $priority_colors: ($red_overdue, $red_overdue, $red_overdue, $red_overdue, $yell
 							height: 44px;
 							width: 44px;
 
-							input[type='checkbox'].checkbox + label::before {
-								border-width: 2px;
-								border-radius: var(--border-radius);
-								border-color: $color-lightgrey;
+							input[type='checkbox'].checkbox + label {
+								&::before {
+									border-width: 2px;
+									border-radius: var(--border-radius);
+								}
+
+								&.priority-high::before {
+									border-color: $red_overdue;
+								}
+								&.priority-medium::before {
+									border-color: $yellow;
+								}
+
+								&.priority-low::before {
+									border-color: $blue_due;
+								}
 							}
 						}
 
@@ -870,7 +872,24 @@ $priority_colors: ($red_overdue, $red_overdue, $red_overdue, $red_overdue, $yell
 
 			.detail-checkbox {
 				padding: 11px 10px;
-				opacity: .5;
+
+				input[type='checkbox'].checkbox + label {
+					&::before {
+						border-width: 2px;
+						border-radius: var(--border-radius);
+					}
+
+					&.priority-high::before {
+						border-color: $red_overdue;
+					}
+					&.priority-medium::before {
+						border-color: $yellow;
+					}
+
+					&.priority-low::before {
+						border-color: $blue_due;
+					}
+				}
 			}
 
 			.title-wrapper {
@@ -1223,6 +1242,11 @@ $priority_colors: ($red_overdue, $red_overdue, $red_overdue, $red_overdue, $yell
 					label {
 						padding-left: 14px;
 						width: 100%;
+
+						&::before {
+							border-width: 2px;
+							border-radius: var(--border-radius);
+						}
 					}
 
 					div,

--- a/css/src/style.scss
+++ b/css/src/style.scss
@@ -426,48 +426,23 @@ $blue_due: #4271a6;			// due dates and low importance
 				}
 			}
 
-
-			/*
-			This mixin is a way to remove the squared corners from the last task of a tree.
-			CSS has no selector for this, this is done using a recursive mixin for up to 8 sublevels of tasks (arbitrary chosen).
-			After this point, the last task of the tree will have squared corners, but nothing will technically break.
-			*/
-
-			@mixin remove-last-squared-corners($sublevels-left: 8) {
-				&>.add-task {
-					&::before {
-						display: block;
-					}
-					&::after {
-						display: none;
-					}
-				}
-				&::before,
-				&>ol:empty::before {
-					display: none !important;
-				}
-				@if $sublevels-left > 0 {
-					&>ol>.task-item:last-child>.subtasks-container {
-						@include remove-last-squared-corners($sublevels-left - 1);
-					}
-				}
-			}
-
-			.grouped-tasks,
-			.sortable-ghost>.subtasks-container {
-				@include remove-last-squared-corners;
-			}
-
 			.grouped-tasks {
 				position: relative;
 				padding-top: 2px;
 
-				>ol {
+				> ol {
 					filter: drop-shadow(0 0 1px var(--color-box-shadow));
 					z-index: 1;
 
 					&:hover {
 						z-index: 10;
+					}
+
+					// Show round corners for first root task
+					> .task-item:first-child > .task-body {
+						border-top-left-radius: var(--border-radius);
+						border-top-right-radius: var(--border-radius);
+						border-top: none;
 					}
 				}
 
@@ -494,34 +469,48 @@ $blue_due: #4271a6;			// due dates and low importance
 						z-index: 5;
 					}
 
-					&.subtasksHidden>.subtasks-container {
-						margin-left: 44px;
-					}
-					&:not(.subtasksHidden)>.subtasks-container {
-						&>ol:not(:empty),
-						&>.add-task + ol,
-						&>.add-task {
-							margin-left: 44px;
+					&.add-task {
+						border-top:  1px solid var(--color-border);
+
+						input {
+							border-top-left-radius: 0;
+							border-top-right-radius: 0;
 						}
 					}
 
-					&.subtasksHidden>.subtasks-container::before,
-					&.subtasksHidden>.subtasks-container>.add-task::before,
-					&.subtasksHidden>.subtasks-container>.add-task::after,
-					&:not(.subtasksHidden)>.subtasks-container>.add-task::before,
-					&>.subtasks-container>ol::before {
-						content: '';
-						display: block;
-						height: 1px;
-						border: 0 solid var(--color-main-background);
-						border-width: var(--border-radius) 0;
-						margin: calc(-1 * var(--border-radius)) 0;
-						background-color: var(--color-background-darker);
-						position: relative;
-						z-index: -1;
+					// Show round corners if a task is the last in the (sub-)list
+					&:last-child .task-body {
+						border-bottom-left-radius: var(--border-radius);
+						border-bottom-right-radius: var(--border-radius);
 					}
-					&.subtasksHidden>.subtasks-container>.add-task::before {
-						display: none;
+
+					// Don't show round corners if any of the ancestors is not the last in the (sub-)list
+					&:not(:last-child) {
+						.add-task input {
+							border-bottom-left-radius: 0;
+							border-bottom-right-radius: 0;
+						}
+						.task-body {
+							border-bottom-left-radius: 0;
+							border-bottom-right-radius: 0;
+						}
+					}
+
+					// If the subtasks container is visible, show a round corner for the task itself and
+					// the next task in the list
+					&.container-visible {
+						& > .task-body {
+							border-bottom-left-radius: var(--border-radius);
+							border-bottom-right-radius: 0;
+						}
+
+						& + .task-item > .task-body {
+							border-top-left-radius: var(--border-radius);
+						}
+					}
+
+					.subtasks-container {
+						margin-left: 44px;
 					}
 
 					.task-body {
@@ -532,7 +521,7 @@ $blue_due: #4271a6;			// due dates and low importance
 						height: 44px;
 						position: relative;
 						background-color: var(--color-main-background);
-						border-radius: var(--border-radius);
+						border-top: 1px solid var(--color-border);
 
 						&:hover {
 							background-color: var(--color-background-hover);

--- a/css/src/style.scss
+++ b/css/src/style.scss
@@ -534,10 +534,12 @@ $blue_due: #4271a6;			// due dates and low importance
 						background-color: var(--color-main-background);
 						border-radius: var(--border-radius);
 
+						&:hover {
+							background-color: var(--color-background-hover);
+						}
+
 						&.active {
-							.task-info .title {
-								font-weight: bold;
-							}
+							background-color: var(--color-primary-light) !important;
 						}
 
 						.task-checkbox {

--- a/css/src/style.scss
+++ b/css/src/style.scss
@@ -437,6 +437,14 @@ $priority_colors: ($red_overdue, $red_overdue, $red_overdue, $red_overdue, $yell
 			*/
 			
 			@mixin remove-last-squared-corners($sublevels-left: 8) {
+				&>.add-task{
+					&::before{
+						display: block;
+					}
+					&::after{
+						display: none;
+					}
+				}
 				&::before,
 				&>ol:empty::before {
 					display: none !important;
@@ -496,6 +504,7 @@ $priority_colors: ($red_overdue, $red_overdue, $red_overdue, $red_overdue, $yell
 					}
 					
 					&.subtasksHidden>.subtasks-container::before,
+					&.subtasksHidden>.subtasks-container>.add-task::before,
 					&.subtasksHidden>.subtasks-container>.add-task::after,
 					&:not(.subtasksHidden)>.subtasks-container>.add-task::before,
 					&>.subtasks-container>ol::before {
@@ -508,6 +517,9 @@ $priority_colors: ($red_overdue, $red_overdue, $red_overdue, $red_overdue, $yell
 						background-color: var(--color-background-darker);
 						position: relative;
 						z-index: -1;
+					}
+					&.subtasksHidden>.subtasks-container>.add-task::before{
+						display: none;
 					}
 					
 					// Apply colors to checkboxes for each non-zero priority level

--- a/css/src/style.scss
+++ b/css/src/style.scss
@@ -482,10 +482,6 @@ $priority_colors: ($red_overdue, $red_overdue, $red_overdue, $red_overdue, $yell
 					&.sortable-ghost {						
 						filter: drop-shadow(0 0 3px var(--color-primary));
 						z-index: 5;
-
-						.task-body {
-							border-radius: var(--border-radius) !important;
-						}
 					}
 					
 					&.subtasksHidden>.subtasks-container {

--- a/css/src/style.scss
+++ b/css/src/style.scss
@@ -445,7 +445,7 @@ $blue_due: #4271a6;			// due dates and low importance
 							border-top-right-radius: var(--border-radius);
 							border-top: none;
 						}
-						
+
 						& > .task-body {
 							@media only screen and (max-width: $breakpoint-mobile) {
 								border-radius: 0 !important;

--- a/css/src/style.scss
+++ b/css/src/style.scss
@@ -439,10 +439,18 @@ $blue_due: #4271a6;			// due dates and low importance
 					}
 
 					// Show round corners for first root task
-					> .task-item:first-child > .task-body {
-						border-top-left-radius: var(--border-radius);
-						border-top-right-radius: var(--border-radius);
-						border-top: none;
+					> .task-item {
+						&:first-child > .task-body {
+							border-top-left-radius: var(--border-radius);
+							border-top-right-radius: var(--border-radius);
+							border-top: none;
+						}
+						
+						& > .task-body {
+							@media only screen and (max-width: $breakpoint-mobile) {
+								border-radius: 0 !important;
+							}
+						}
 					}
 				}
 

--- a/css/src/style.scss
+++ b/css/src/style.scss
@@ -486,6 +486,7 @@ $blue_due: #4271a6;			// due dates and low importance
 
 					// Don't show round corners if any of the ancestors is not the last in the (sub-)list
 					&:not(:last-child) {
+						&.add-task input,
 						.add-task input {
 							border-bottom-left-radius: 0;
 							border-bottom-right-radius: 0;

--- a/css/src/style.scss
+++ b/css/src/style.scss
@@ -500,9 +500,11 @@ $priority_colors: ($red_overdue, $red_overdue, $red_overdue, $red_overdue, $yell
 						&::before {
 							content: '';
 							display: block;
-							padding: var(--border-radius);
+							height: 1px;
+							border: 0 solid var(--color-main-background);
+							border-width: var(--border-radius) 0;
 							margin: calc(-1 * var(--border-radius)) 0;
-							background: var(--color-main-background);
+							background-color: var(--color-background-darker);
 							position: relative;
 							z-index: -1;
 						}
@@ -532,7 +534,6 @@ $priority_colors: ($red_overdue, $red_overdue, $red_overdue, $red_overdue, $yell
 						position: relative;
 						background-color: var(--color-main-background);
 						border-radius: var(--border-radius);
-						box-shadow: inset 0 2px 0 -1px var(--color-background-darker);
 
 						&.active {
 							.task-info .title {

--- a/css/src/style.scss
+++ b/css/src/style.scss
@@ -541,7 +541,7 @@ $blue_due: #4271a6;			// due dates and low importance
 						}
 
 						.task-checkbox {
-							padding: 12px 10px;
+							padding: 11px 10px;
 							height: 44px;
 							width: 44px;
 

--- a/src/components/TaskBody.vue
+++ b/src/components/TaskBody.vue
@@ -23,7 +23,7 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 <template>
 	<li v-show="showTask"
 		:task-id="task.uri"
-		:class="{done: task.completed, readOnly: readOnly, deleted: !!deleteTimeout}"
+		:class="{done: task.completed, readOnly: readOnly, deleted: !!deleteTimeout, subtasksHidden: !showSubtasks}"
 		:data-priority="[task.priority]"
 		class="task-item"
 		@dragstart="dragStart($event)">

--- a/src/components/TaskBody.vue
+++ b/src/components/TaskBody.vue
@@ -23,7 +23,13 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 <template>
 	<li v-show="showTask"
 		:task-id="task.uri"
-		:class="{done: task.completed, readOnly: readOnly, deleted: !!deleteTimeout, subtasksHidden: !showSubtasks}"
+		:class="{
+			done: task.completed,
+			readOnly: readOnly,
+			deleted: !!deleteTimeout,
+			subtasksHidden: !showSubtasks,
+			'container-visible': ((showSubtasks && filteredSubtasks.length) || showSubtaskInput)
+		}"
 		:data-priority="[task.priority]"
 		class="task-item"
 		@dragstart="dragStart($event)">

--- a/src/components/TaskBody.vue
+++ b/src/components/TaskBody.vue
@@ -44,7 +44,7 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 					:disabled="readOnly"
 					:aria-label="$t('tasks', 'Task is completed')"
 					@click="toggleCompleted(task)">
-				<label class="reactive no-nav" :for="'toggleCompleted_' + task.uid" />
+				<label :class="[checkboxColor, 'reactive no-nav']" :for="'toggleCompleted_' + task.uid" />
 			</div>
 			<!-- Info: title, progress & categories -->
 			<div class="task-info">
@@ -293,16 +293,26 @@ export default {
 			}
 		},
 
-		iconStar() {
+		priorityClass() {
 			if (+this.task.priority > 5) {
-				return 'sprt-color sprt-task-star-low'
+				return 'low'
 			} else if (+this.task.priority === 5) {
-				return 'sprt-color sprt-task-star-medium'
+				return 'medium'
 			} else if (+this.task.priority > 0 && +this.task.priority < 5) {
-				return 'sprt-color sprt-task-star-high'
+				return 'high'
 			} else {
-				return 'icon-sprt-bw sprt-task-star'
+				return ''
 			}
+		},
+
+		checkboxColor() {
+			const priority = this.priorityClass
+			return priority ? `priority-${priority}` : ''
+		},
+
+		iconStar() {
+			const priority = this.priorityClass
+			return priority ? `sprt-color sprt-task-star-${priority}` : 'icon-sprt-bw sprt-task-star'
 		},
 
 		hasCompletedSubtasks() {

--- a/src/components/TaskDragContainer.vue
+++ b/src/components/TaskDragContainer.vue
@@ -20,7 +20,8 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <template>
-	<draggable tag="ol"
+	<draggable v-if="sortedTasks.length"
+		tag="ol"
 		:list="['']"
 		:set-data="setDragData"
 		v-bind="{group: 'tasks', swapThreshold: 0.30, delay: 500, delayOnTouchOnly: true, touchStartThreshold: 3, disabled: disabled, filter: '.readOnly'}"

--- a/src/components/TheDetails.vue
+++ b/src/components/TheDetails.vue
@@ -36,7 +36,7 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 						:disabled="readOnly"
 						:aria-label="$t('tasks', 'Task is completed')"
 						@click="toggleCompleted(task)">
-					<label :for="'detailsToggleCompleted_' + task.uid" />
+					<label :class="[checkboxColor]" :for="'detailsToggleCompleted_' + task.uid" />
 				</span>
 				<div v-click-outside="() => finishEditing('summary')" class="title-wrapper">
 					<div v-linkify="task.summary"
@@ -617,6 +617,10 @@ export default {
 				return this.$t('tasks', 'Priority {priority}: low', { priority: this.task.priority })
 			}
 			return ''
+		},
+		checkboxColor() {
+			const priority = this.priorityClass
+			return priority ? `priority-${priority}` : ''
 		},
 		completeString() {
 			return this.$t('tasks', '{percent} % completed', { percent: this.task.complete })


### PR DESCRIPTION
Follow-up of #1135. Updates the style of the task list to a more friendly appearance. Please have a look @timkrief 

![tasklist](https://user-images.githubusercontent.com/2496460/88585315-3c415900-d053-11ea-9457-f49975e1f6f9.gif)

Also @jancborchardt and @nextcloud/designers for review.

![Screenshot_2020-07-27 Tasks - Nextcloud](https://user-images.githubusercontent.com/2496460/88585733-ba9dfb00-d053-11ea-87fc-50c71f2c1a3c.png)

