### PR TITLE
Fix Internal Server Error when not logged in

### DIFF
--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -27,7 +27,7 @@ use OCP\IConfig;
 class SettingsService {
 
 	/**
-	 * @var string
+	 * @var ?string
 	 */
 	private $userId;
 
@@ -46,7 +46,7 @@ class SettingsService {
 	 * @param IConfig $settings
 	 * @param string $appName
 	 */
-	public function __construct(string $userId, IConfig $config, string $appName) {
+	public function __construct(?string $userId, IConfig $config, string $appName) {
 		$this->userId = $userId;
 		$this->config = $config;
 		$this->appName = $appName;


### PR DESCRIPTION
When not logged in, accessing any Tasks page results in an Internal Server Error. This is because `$userId` is `NULL`, and SettingsService only accepts strings for user ids. As the error occurs during dependency injection of `PageController`, automatic redirects to the login page do not work.
This PR makes SettingsService accept `NULL` using nullable types, so Nextcloud can properly redirect the user to the login screen.

Error in log:
![error-log](https://user-images.githubusercontent.com/615611/88202707-8e484000-cc49-11ea-93e9-8cf979cba9d1.png)

Error on web page:
![error-page](https://user-images.githubusercontent.com/615611/88202709-8ee0d680-cc49-11ea-9a0a-f8124204376d.png)
