### PR TITLE
Remove linebreaks and tabs from translate function

### DIFF
--- a/src/components/AppNavigation/AppNavigation.vue
+++ b/src/components/AppNavigation/AppNavigation.vue
@@ -323,13 +323,7 @@ export default {
 				msg: '',
 			}
 			if (this.isCalendarNameUsed(name, id)) {
-				check.msg = this.$t(
-					'tasks',
-					'The name "{calendar}" is already used.',
-					{ calendar: name },
-					undefined,
-					{ sanitize: false, escape: false }
-				)
+				check.msg = this.$t('tasks', 'The name "{calendar}" is already used.', { calendar: name }, undefined, { sanitize: false, escape: false })
 			} else if (!name) {
 				check.msg = this.$t('tasks', 'An empty name is not allowed.')
 			} else {

--- a/src/components/AppNavigation/ListItemCalendar.vue
+++ b/src/components/AppNavigation/ListItemCalendar.vue
@@ -205,37 +205,13 @@ export default {
 
 		deleteMessage() {
 			return !this.calendar.isSharedWithMe
-				? this.$t(
-					'tasks',
-					'This will delete the calendar "{calendar}" and all corresponding events and tasks.',
-					{ calendar: this.calendar.displayName },
-					undefined,
-					{ sanitize: false, escape: false }
-				)
-				: this.$t(
-					'tasks',
-					'This will unshare the calendar "{calendar}".',
-					{ calendar: this.calendar.displayName },
-					undefined,
-					{ sanitize: false, escape: false }
-				)
+				? this.$t('tasks', 'This will delete the calendar "{calendar}" and all corresponding events and tasks.', { calendar: this.calendar.displayName }, undefined, { sanitize: false, escape: false })
+				: this.$t('tasks', 'This will unshare the calendar "{calendar}".', { calendar: this.calendar.displayName }, undefined, { sanitize: false, escape: false })
 		},
 		undoDeleteMessage() {
 			return !this.calendar.isSharedWithMe
-				? this.$n(
-					'tasks',
-					'Deleting the calendar in {countdown} second',
-					'Deleting the calendar in {countdown} seconds',
-					this.countdown,
-					{ countdown: this.countdown }
-				)
-				: this.$n(
-					'tasks',
-					'Unsharing the calendar in {countdown} second',
-					'Unsharing the calendar in {countdown} seconds',
-					this.countdown,
-					{ countdown: this.countdown }
-				)
+				? this.$n('tasks', 'Deleting the calendar in {countdown} second', 'Deleting the calendar in {countdown} seconds', this.countdown, { countdown: this.countdown })
+				: this.$n('tasks', 'Unsharing the calendar in {countdown} second', 'Unsharing the calendar in {countdown} seconds', this.countdown, { countdown: this.countdown })
 		},
 		sharingIconClass() {
 			if (this.calendar.shares.length) {

--- a/src/components/DeleteCompletedModal.vue
+++ b/src/components/DeleteCompletedModal.vue
@@ -31,16 +31,7 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 				<p class="icon-delete" />
 				<div v-if="completedTasksCount">
 					<h3 class="delete-completed__header">
-						{{ $n('tasks',
-							'This will delete {taskCount} completed task and its subtasks from calendar "{calendar}".',
-							'This will delete {taskCount} completed tasks and their subtasks from calendar "{calendar}".',
-							initialCompletedRootTasksCount,
-							{
-								taskCount: initialCompletedRootTasksCount,
-								calendar: calendar.displayName
-							},
-							{ sanitize: false, escape: false }
-						) }}
+						{{ $n('tasks', 'This will delete {taskCount} completed task and its subtasks from calendar "{calendar}".', 'This will delete {taskCount} completed tasks and their subtasks from calendar "{calendar}".', initialCompletedRootTasksCount, {taskCount: initialCompletedRootTasksCount, calendar: calendar.displayName}, { sanitize: false, escape: false }) }}
 					</h3>
 					<button class="delete-completed__button icon-delete"
 						type="button"
@@ -50,12 +41,7 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 				</div>
 				<div v-else>
 					<h3 class="delete-completed__header">
-						{{ $t('tasks',
-							'Deleted all completed tasks from calendar "{calendar}".',
-							{ calendar: calendar.displayName },
-							undefined,
-							{ sanitize: false, escape: false }
-						) }}
+						{{ $t('tasks', 'Deleted all completed tasks from calendar "{calendar}".', { calendar: calendar.displayName }, undefined, { sanitize: false, escape: false }) }}
 					</h3>
 				</div>
 				<div>
@@ -66,12 +52,7 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 							{{ $t('tasks', 'No errors') }}
 						</span>
 						<span v-else v-tooltip.auto="$t('tasks', 'Open your browser console for more details')">
-							{{ $n('tasks',
-								'Could not delete {failedCount} task.',
-								'Could not delete {failedCount} tasks.',
-								failed,
-								{ failedCount: failed }
-							) }}
+							{{ $n('tasks', 'Could not delete {failedCount} task.', 'Could not delete {failedCount} tasks.', failed, { failedCount: failed }) }}
 						</span>
 					</p>
 				</div>

--- a/src/components/TaskBody.vue
+++ b/src/components/TaskBody.vue
@@ -338,13 +338,7 @@ export default {
 		 * @returns {String} the placeholder string to show
 		 */
 		subtasksCreationPlaceholder() {
-			return this.$t(
-				'tasks',
-				'Add a subtask to "{task}"…',
-				{ task: this.task.summary },
-				undefined,
-				{ sanitize: false, escape: false }
-			)
+			return this.$t('tasks', 'Add a subtask to "{task}"…', { task: this.task.summary }, undefined, { sanitize: false, escape: false })
 		},
 
 		/**

--- a/src/components/TheCollections/Calendar.vue
+++ b/src/components/TheCollections/Calendar.vue
@@ -99,13 +99,7 @@ export default {
 		},
 
 		inputString() {
-			return this.$t(
-				'tasks',
-				'Add a task to "{task}"…',
-				{ task: this.calendar.displayName },
-				undefined,
-				{ sanitize: false, escape: false }
-			)
+			return this.$t('tasks', 'Add a task to "{task}"…', { task: this.calendar.displayName }, undefined, { sanitize: false, escape: false })
 		},
 
 		/**

--- a/src/components/TheCollections/General.vue
+++ b/src/components/TheCollections/General.vue
@@ -109,37 +109,13 @@ export default {
 		inputString() {
 			switch (this.collectionId) {
 			case 'starred':
-				return this.$t(
-					'tasks',
-					'Add an important task to "{calendar}"…',
-					{ calendar: this.calendar.displayName },
-					undefined,
-					{ sanitize: false, escape: false }
-				)
+				return this.$t('tasks', 'Add an important task to "{calendar}"…', { calendar: this.calendar.displayName }, undefined, { sanitize: false, escape: false })
 			case 'today':
-				return this.$t(
-					'tasks',
-					'Add a task due today to "{calendar}"…',
-					{ calendar: this.calendar.displayName },
-					undefined,
-					{ sanitize: false, escape: false }
-				)
+				return this.$t('tasks', 'Add a task due today to "{calendar}"…', { calendar: this.calendar.displayName }, undefined, { sanitize: false, escape: false })
 			case 'current':
-				return this.$t(
-					'tasks',
-					'Add a current task to "{calendar}"…',
-					{ calendar: this.calendar.displayName },
-					undefined,
-					{ sanitize: false, escape: false }
-				)
+				return this.$t('tasks', 'Add a current task to "{calendar}"…', { calendar: this.calendar.displayName }, undefined, { sanitize: false, escape: false })
 			default:
-				return this.$t(
-					'tasks',
-					'Add a task to "{calendar}"…',
-					{ calendar: this.calendar.displayName },
-					undefined,
-					{ sanitize: false, escape: false }
-				)
+				return this.$t('tasks', 'Add a task to "{calendar}"…', { calendar: this.calendar.displayName }, undefined, { sanitize: false, escape: false })
 			}
 		},
 		...mapGetters({

--- a/src/components/TheCollections/Week.vue
+++ b/src/components/TheCollections/Week.vue
@@ -104,13 +104,7 @@ export default {
 		},
 
 		inputString() {
-			return this.$t(
-				'tasks',
-				'Add a task due today to "{calendar}"…',
-				{ calendar: this.calendar.displayName },
-				undefined,
-				{ sanitize: false, escape: false }
-			)
+			return this.$t('tasks', 'Add a task due today to "{calendar}"…', { calendar: this.calendar.displayName }, undefined, { sanitize: false, escape: false })
 		},
 	},
 	methods: {


### PR DESCRIPTION
This PR tests if the linebreaks and tabs in the argument list of the translate `t` and `n` functions break the transifex string extraction script. Related to #1147.