### PR TITLE
Fix dragging to tasks without (visible) subtasks

### DIFF
--- a/css/src/style.scss
+++ b/css/src/style.scss
@@ -480,8 +480,7 @@ $blue_due: #4271a6;			// due dates and low importance
 						border-top: 1px solid var(--color-border);
 
 						input {
-							border-top-left-radius: 0;
-							border-top-right-radius: 0;
+							border-radius: 0;
 						}
 					}
 
@@ -491,9 +490,13 @@ $blue_due: #4271a6;			// due dates and low importance
 						border-bottom-right-radius: var(--border-radius);
 					}
 
+					&:not(.subtasks-visible) .add-task input {
+						border-bottom-left-radius: var(--border-radius);
+						border-bottom-right-radius: var(--border-radius);
+					}
+
 					// Don't show round corners if any of the ancestors is not the last in the (sub-)list
 					&:not(:last-child) {
-						&.add-task input,
 						.add-task input {
 							border-bottom-left-radius: 0;
 							border-bottom-right-radius: 0;

--- a/src/components/TaskBody.vue
+++ b/src/components/TaskBody.vue
@@ -28,7 +28,8 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 			readOnly: readOnly,
 			deleted: !!deleteTimeout,
 			subtasksHidden: !showSubtasks,
-			'container-visible': ((showSubtasks && filteredSubtasks.length) || showSubtaskInput)
+			'container-visible': (filteredSubtasksShown.length || showSubtaskInput),
+			'subtasks-visible': filteredSubtasksShown.length
 		}"
 		:data-priority="[task.priority]"
 		class="task-item"

--- a/src/components/TaskBody.vue
+++ b/src/components/TaskBody.vue
@@ -143,8 +143,8 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 						@keyup.27="showSubtaskInput = false">
 				</form>
 			</div>
-			<TaskDragContainer v-if="showSubtasks"
-				:tasks="filteredSubtasks"
+			<TaskDragContainer
+				:tasks="filteredSubtasksShown"
 				:disabled="task.calendar.readOnly"
 				:collection-string="collectionString"
 				:task-id="task.uri"
@@ -346,7 +346,7 @@ export default {
 		 * filtered by collections (for week, today, important and current) when
 		 * the task is not opened in details view.
 		 *
-		 * @returns {Array} the array with the subtasks to show
+		 * @returns {Array} the array with the filtered subtasks
 		 */
 		filteredSubtasks() {
 			let subTasks = Object.values(this.task.subTasks)
@@ -362,6 +362,18 @@ export default {
 				})
 			}
 			return subTasks
+		},
+
+		/**
+		 * Returns the filtered subtasks or an empty array if the subtasks should be hidden.
+		 *
+		 * @returns {Array} the array with the subtasks to show
+		 */
+		filteredSubtasksShown() {
+			 if (this.showSubtasks) {
+				return this.filteredSubtasks
+			 }
+			 return []
 		},
 
 		/**

--- a/src/components/TaskDragContainer.vue
+++ b/src/components/TaskDragContainer.vue
@@ -20,8 +20,7 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <template>
-	<draggable v-if="sortedTasks.length"
-		tag="ol"
+	<draggable tag="ol"
 		:list="['']"
 		:set-data="setDragData"
 		v-bind="{group: 'tasks', swapThreshold: 0.30, delay: 500, delayOnTouchOnly: true, touchStartThreshold: 3, disabled: disabled, filter: '.readOnly'}"


### PR DESCRIPTION
This fixes the drag and drop to parent tasks without subtasks, which was broken by #1136. Closes #1149.

Additionally it is now also possible to drag to parent tasks which have their subtasks hidden.