### PR TITLE
Better indicate dropping on empty completed list

### DIFF
--- a/css/src/style.scss
+++ b/css/src/style.scss
@@ -443,6 +443,10 @@ $blue_due: #4271a6;			// due dates and low importance
 						z-index: 10;
 					}
 
+					&.completed {
+						margin-top: 12px;
+					}
+
 					// Show round corners for first root task
 					> .task-item {
 						&:first-child > .task-body {
@@ -776,7 +780,6 @@ $blue_due: #4271a6;			// due dates and low importance
 	.heading {
 		display: flex;
 		align-items: center;
-		margin-bottom: 10px;
 		margin-top: 20px !important;
 
 		@media only screen and (max-width: $breakpoint-mobile) {
@@ -784,6 +787,8 @@ $blue_due: #4271a6;			// due dates and low importance
 		}
 
 		&--hiddentasks {
+			margin-bottom: 0;
+
 			.heading__title {
 				display: inline-block;
 				padding-right: 16px;

--- a/src/components/TheCollections/Calendar.vue
+++ b/src/components/TheCollections/Calendar.vue
@@ -50,6 +50,7 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 					:tasks="completedRootTasks(calendar.tasks)"
 					:calendar-id="calendarId"
 					:disabled="calendar.readOnly"
+					class="completed"
 					collection-id="completed" />
 				<LoadCompletedButton :calendar="calendar" />
 				<DeleteCompletedModal v-if="calendar.loadedCompleted && !calendar.readOnly" :calendar="calendar" />


### PR DESCRIPTION
When dragging a task to the last position in the list it could happen, that it was marked as completed, since the empty completed list had no spacer to the normal list. We now have a small distance to the completed list, so it is more obivous a task will be completed.

Before:
![before](https://user-images.githubusercontent.com/2496460/89215626-43271900-d5c9-11ea-9aaa-515f6bffafa3.gif)

After:
![after](https://user-images.githubusercontent.com/2496460/89215607-3c98a180-d5c9-11ea-965f-e3f0d2464b39.gif)
