### PR TITLE
Reduce subtasks container padding on mobile

### DIFF
--- a/css/src/style.scss
+++ b/css/src/style.scss
@@ -484,6 +484,10 @@ $blue_due: #4271a6;			// due dates and low importance
 
 					.subtasks-container {
 						margin-left: 44px;
+
+						@media only screen and (max-width: $breakpoint-mobile) {
+							margin-left: 14px;
+						}
 					}
 
 					.task-body {


### PR DESCRIPTION
Gives more space to the content.

Before:
![Screenshot_2020-10-13 Tasks - Nextcloud(1)](https://user-images.githubusercontent.com/2496460/95909425-c372b300-0d9e-11eb-9518-09379272000e.png)


After:
![Screenshot_2020-10-13 Tasks - Nextcloud](https://user-images.githubusercontent.com/2496460/95909416-c077c280-0d9e-11eb-9730-13897d45e228.png)
