### PR TITLE
Fix sorting calendars on mobile

### DIFF
--- a/src/components/AppNavigation/AppNavigation.vue
+++ b/src/components/AppNavigation/AppNavigation.vue
@@ -45,6 +45,7 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 			</AppNavigationItem>
 			<draggable
 				:set-data="setData"
+				v-bind="{swapThreshold: 0.30, delay: 500, delayOnTouchOnly: true, touchStartThreshold: 3}"
 				@update="update">
 				<ListItemCalendar
 					v-for="calendar in calendars"


### PR DESCRIPTION
Sorting calendars on mobile now only starts after a short delay, ensuring it is still possible to just scroll the list and click the calendar conveniently. Closes #1278.