### PR TITLE
Fix stylelint

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,2 @@
+vendor/**/*.css
+coverage/**/*.css


### PR DESCRIPTION
For some reason stylelint started to lint CSS files in `coverage` and `vendor` causing the build to fail. This fixes  it.