### PR TITLE
Provide calendar settings as initial state

### DIFF
--- a/src/store/settings.js
+++ b/src/store/settings.js
@@ -70,6 +70,22 @@ const getters = {
 	 * @returns {String} Whether all-day is default
 	 */
 	initialRoute: (state) => state.settings.initialRoute,
+
+	/**
+	 * Returns whether we can show tasks in the Calendar app
+	 *
+	 * @param {Object} state The store data
+	 * @returns {Boolean} Whether we can show tasks in Calendar app
+	 */
+	showTaskInCalendar: (state) => state.settings.calendarEnabled && state.settings.showTasks,
+
+	/**
+	 * Returns the current view of the Calendar app
+	 *
+	 * @param {Object} state The store data
+	 * @returns {String} The current view of the Calendar app
+	 */
+	calendarView: (state) => state.settings.calendarView,
 }
 
 const mutations = {
@@ -122,6 +138,9 @@ const actions = {
 			sortDirection: loadState('tasks', 'sortDirection'),
 			allDay: loadState('tasks', 'allDay'),
 			initialRoute: loadState('tasks', 'initialRoute'),
+			calendarEnabled: loadState('tasks', 'calendarEnabled'),
+			showTasks: loadState('tasks', 'showTasks'),
+			calendarView: loadState('tasks', 'calendarView'),
 		})
 	},
 }


### PR DESCRIPTION
This provides information to the app if the Calendar app is enabled and if show-tasks is enabled.

This is a preparation for #1030 to not bloat the AppSidebar PR even more.