### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Then open the Tasks app from the app menu.
 * [Vdirsyncer](https://vdirsyncer.pimutils.org/en/stable/) (Linux)
 * [BusyCal](https://www.busymac.com/busycal) (MacOS)
 * [aCalendar+](https://acalendar.tapirapps.de/de/support/home) (via Davx5) [(Android)](https://play.google.com/store/apps/details?id=org.withouthat.acalendarplus)
-* [GNOME Todo](https://wiki.gnome.org/Apps/Todo) (Linux)
+* [GNOME Todo](https://wiki.gnome.org/Apps/Todo) (via [GNOME Online Accounts](https://wiki.gnome.org/Design/SystemSettings/OnlineAccounts)) (Linux)
 
 ## Maintainers
 


### PR DESCRIPTION
Added information on syncing nextcloud to GNOME To Do. Direct caldav support is currently not supported: https://gitlab.gnome.org/GNOME/gnome-todo/-/issues/45