### PR TITLE
Don't provide username null

### DIFF
--- a/src/components/AppSidebar/CalendarPickerOption.vue
+++ b/src/components/AppSidebar/CalendarPickerOption.vue
@@ -81,24 +81,24 @@ export default {
 		/**
 		 * Gets the user-id of the calendar's owner
 		 *
-		 * @returns {null|String}
+		 * @returns {undefined|String}
 		 */
 		userId() {
 			if (this.principal) {
 				return this.principal.userId
 			}
-			return null
+			return undefined
 		},
 		/**
 		 * Gets the displayname of the calendar's owner
 		 *
-		 * @returns {null|String}
+		 * @returns {undefined|String}
 		 */
 		userDisplayName() {
 			if (this.principal) {
 				return this.principal.displayname
 			}
-			return null
+			return undefined
 		},
 	},
 }


### PR DESCRIPTION
Fix username is null error in the Avatar component https://github.com/nextcloud/nextcloud-vue/issues/1856

Turns out I was using it wrong. When no user was found (yet), I set `displayName` to `null` while the `Avatar` component assumes `undefined`.