### PR TITLE
Don't explicitly require babel object rest spread

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
 				"vuex-router-sync": "^5.0.0"
 			},
 			"devDependencies": {
-				"@babel/plugin-proposal-object-rest-spread": "^7.14.5",
 				"@nextcloud/babel-config": "^1.0.0-beta.1",
 				"@nextcloud/browserslist-config": "^2.1.0",
 				"@nextcloud/eslint-config": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
 		"vuex-router-sync": "^5.0.0"
 	},
 	"devDependencies": {
-		"@babel/plugin-proposal-object-rest-spread": "^7.14.5",
 		"@nextcloud/babel-config": "^1.0.0-beta.1",
 		"@nextcloud/browserslist-config": "^2.1.0",
 		"@nextcloud/eslint-config": "^5.1.0",


### PR DESCRIPTION
As per https://github.com/nextcloud/tasks/pull/1638#discussion_r650381114