### PR TITLE
Remove support for Nextcloud server v19

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -20,7 +20,7 @@
     <repository>https://github.com/nextcloud/tasks.git</repository>
     <screenshot>https://raw.githubusercontent.com/nextcloud/tasks/master/screenshots/tasks-1.png</screenshot>
     <dependencies>
-        <nextcloud min-version="19" max-version="23"/>
+        <nextcloud min-version="20" max-version="23"/>
     </dependencies>
     <navigations>
         <navigation>

--- a/src/main.js
+++ b/src/main.js
@@ -121,15 +121,8 @@ OCA.Tasks.App = new Vue({
 		}
 	},
 	mounted() {
-		const version = this.$OC.config.version.split('.')
-
-		if (version[0] >= 20) {
-			// Hook to new global event for unified search
-			subscribe('nextcloud:unified-search.search', this.filterProxy)
-			subscribe('nextcloud:unified-search.reset', this.cleanSearch)
-		} else {
-			this.$OC.Search = new OCA.Search(this.filter, this.cleanSearch)
-		}
+		subscribe('nextcloud:unified-search.search', this.filterProxy)
+		subscribe('nextcloud:unified-search.reset', this.cleanSearch)
 	},
 	beforeMount() {
 		this.$store.dispatch('loadCollections')


### PR DESCRIPTION
Nextcloud server 19 will be end-of-life with the release of Nextcloud server 22, so we can remove the support for it (and finally get rid of the search deprecation warning 🎉). 