### PR TITLE
Adjust the app-navigation-toggle alignment

### DIFF
--- a/css/tasks.scss
+++ b/css/tasks.scss
@@ -21,6 +21,16 @@
 
 @include icon-black-white('circle', 'tasks', 1);
 
+// Adjust app-navigation-toggle position
+button.app-navigation-toggle {
+	top: 12px !important;
+	right: -15px !important;
+
+	@media only screen and (max-width: $breakpoint-mobile) {
+		right: 0 !important;
+	}
+}
+
 // Hack for https://github.com/nextcloud/nextcloud-vue/issues/1384
 body {
 	min-height: 100%;

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -116,7 +116,7 @@ export default {
 $breakpoint-mobile: 1024px;
 
 .header {
-	padding: 12px 15px 12px 44px;
+	padding: 12px 15px 12px 59px;
 	position: sticky;
 	top: 50px;
 	background-color: var(--color-background-dark);
@@ -125,6 +125,7 @@ $breakpoint-mobile: 1024px;
 
 	@media only screen and (max-width: $breakpoint-mobile) {
 		padding-right: 0;
+		padding-left: 44px;
 	}
 
 	&__input {


### PR DESCRIPTION
Looks like this now on wide screens:
![Screenshot 2021-06-29 at 22-34-39 Tasks - Nextcloud](https://user-images.githubusercontent.com/2496460/123863805-50a86880-d92a-11eb-87f8-19e7b76c0d8d.png)

And on narrow screens:
![Screenshot 2021-06-29 at 22-35-03 Tasks - Nextcloud](https://user-images.githubusercontent.com/2496460/123863828-569e4980-d92a-11eb-9208-9a68bbbaab89.png)

Closes #1666.