### PR TITLE
Fix moving tasks back and forth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
 				"@nextcloud/vue-dashboard": "^2.0.1",
 				"@vue/test-utils": "^1.2.1",
 				"calendar-js": "github:nextcloud/calendar-js",
-				"cdav-library": "github:nextcloud/cdav-library",
+				"cdav-library": "github:nextcloud/cdav-library#82c0d19b1e92a57109380a8243b37a8f917c3997",
 				"color-convert": "^2.0.1",
 				"debounce": "^1.2.1",
 				"ical.js": "github:raimund-schluessler/ical.js#306bd3f02287f75911c49078bd483f966a025438",
@@ -4774,8 +4774,8 @@
 		},
 		"node_modules/cdav-library": {
 			"version": "0.0.1",
-			"resolved": "git+ssh://git@github.com/nextcloud/cdav-library.git#e62c7c9942d6759743dc9a0350921e898440f2d5",
-			"integrity": "sha512-xgZ7MVeYeiXwQl5SuyXRVxXPM2swxG46HS0m0IFQ2SmzOgBTm3AdzUFJicggJ34e3SIzrFniWaftkhr550eyJw==",
+			"resolved": "git+ssh://git@github.com/nextcloud/cdav-library.git#82c0d19b1e92a57109380a8243b37a8f917c3997",
+			"integrity": "sha512-nA52mSyDqnPVmhv6pJW9sE2mDqAVsnczoe44L2CtwxY0C5uzFMMtyqiqVToHsjPSkVLda6Syc8Abbt+ZhJmo1A==",
 			"license": "AGPL-3.0",
 			"dependencies": {
 				"core-js": "^3.15.2",
@@ -20623,9 +20623,9 @@
 			"integrity": "sha512-o0PRQSrSCGJKCPZcgMzl5fUaj5xHe8qA2m4QRvnyY4e1lITqoNkr7q/Oh1NcpGSy0Th97UZ35yoKcINPoq7YOQ=="
 		},
 		"cdav-library": {
-			"version": "git+ssh://git@github.com/nextcloud/cdav-library.git#e62c7c9942d6759743dc9a0350921e898440f2d5",
-			"integrity": "sha512-xgZ7MVeYeiXwQl5SuyXRVxXPM2swxG46HS0m0IFQ2SmzOgBTm3AdzUFJicggJ34e3SIzrFniWaftkhr550eyJw==",
-			"from": "cdav-library@github:nextcloud/cdav-library",
+			"version": "git+ssh://git@github.com/nextcloud/cdav-library.git#82c0d19b1e92a57109380a8243b37a8f917c3997",
+			"integrity": "sha512-nA52mSyDqnPVmhv6pJW9sE2mDqAVsnczoe44L2CtwxY0C5uzFMMtyqiqVToHsjPSkVLda6Syc8Abbt+ZhJmo1A==",
+			"from": "cdav-library@github:nextcloud/cdav-library#82c0d19b1e92a57109380a8243b37a8f917c3997",
 			"requires": {
 				"core-js": "^3.15.2",
 				"regenerator-runtime": "^0.13.7"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"@nextcloud/vue-dashboard": "^2.0.1",
 		"@vue/test-utils": "^1.2.1",
 		"calendar-js": "github:nextcloud/calendar-js",
-		"cdav-library": "github:nextcloud/cdav-library",
+		"cdav-library": "github:nextcloud/cdav-library#82c0d19b1e92a57109380a8243b37a8f917c3997",
 		"color-convert": "^2.0.1",
 		"debounce": "^1.2.1",
 		"ical.js": "github:raimund-schluessler/ical.js#306bd3f02287f75911c49078bd483f966a025438",

--- a/src/store/tasks.js
+++ b/src/store/tasks.js
@@ -1366,7 +1366,9 @@ const actions = {
 				await context.dispatch('moveTask', { task: subTask, calendar, parent: task })
 			}))
 
-			await task.dav.move(calendar.dav)
+			await task.dav.move(calendar.dav, true, {
+				'X-NC-CalDAV-No-Trashbin': 1,
+			})
 				.then((response) => {
 					context.commit('deleteTaskFromCalendar', task)
 					context.commit('deleteTask', task)


### PR DESCRIPTION
This is the first attempt to (hot-)fix moving tasks between lists, see #1685.

Requires https://github.com/nextcloud/cdav-library/pull/514 for actually sending the correct header to server.

Unfortunately, the server does not seem to respect neither the `X-NC-CalDAV-No-Trashbin` header nor the request to overwrite existing dav objects.

So this will definitely need fixes on the server side. Until this is fixed in server, one can only delete the trash bin entry and then move the task back.