### PR TITLE
Show task title in appsidebar title tooltip

### DIFF
--- a/src/views/AppSidebar.vue
+++ b/src/views/AppSidebar.vue
@@ -25,6 +25,7 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 		:title-editable="editingTitle"
 		:linkify-title="true"
 		:subtitle="subtitle"
+		:title-tooltip="title"
 		:empty="!task"
 		@start-editing="newTitle = task.summary"
 		@update:titleEditable="editTitle"


### PR DESCRIPTION
Looks like this:
<img width="347" alt="tooltip" src="https://user-images.githubusercontent.com/2496460/126082718-c36df3d1-f9eb-43c5-a69b-4b9af9c0c336.png">

Closes #1699 