### PR TITLE
increase size of `load all completed tasks` button

### DIFF
--- a/src/components/DeleteCompletedModal.vue
+++ b/src/components/DeleteCompletedModal.vue
@@ -144,16 +144,15 @@ export default {
 
 <style lang="scss" scoped>
 .loadmore {
-	font-size: 11px;
-	margin-top: 10px;
 	text-align: center;
-	height: 21px;
+	top: 20px;
+	position: relative;
 
 	span {
 		color: var(--color-text-lighter);
 		background-color: var(--color-main-background);
 		border-radius: var(--border-radius-pill);
-		padding: 3px 6px;
+		padding: 10px;
 
 		&:hover {
 			cursor: pointer;

--- a/src/components/LoadCompletedButton.vue
+++ b/src/components/LoadCompletedButton.vue
@@ -59,16 +59,15 @@ export default {
 
 <style lang="scss" scoped>
 .loadmore {
-	font-size: 11px;
-	margin-top: 10px;
 	text-align: center;
-	height: 21px;
+	top: 20px;
+	position: relative;
 
 	span {
 		color: var(--color-text-lighter);
 		background-color: var(--color-main-background);
 		border-radius: var(--border-radius-pill);
-		padding: 3px 6px;
+		padding: 10px;
 
 		&:hover {
 			cursor: pointer;


### PR DESCRIPTION
Fix #1667
Signed-off-by: szaimen <szaimen@e.mail.de>

<details>
<summary>For my own testing</summary>

```
docker run -d \
-e TASKS_BRANCH=enh/1667/increase-button-size \
-p 8443:443 \
-e TRUSTED_DOMAIN=192.168.178.34 \
--name nextcloud-easy-test \
--user=www-data \
ghcr.io/szaimen/nextcloud-easy-test:latest
```

</details>