### PR TITLE
Fix Thunderbird Lightning URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Then open the Tasks app from the app menu.
 * [Outlook Caldav Synchronizer](https://caldavsynchronizer.org/)  (Windows)
 * [Tasks: Astrid Todo List Clone](https://tasks.org/)  [(Android)](https://play.google.com/store/apps/details?id=org.tasks&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1)
 * [Qownnotes](https://www.qownnotes.org/) (Read-only, Cross Platform Desktop App)
-* [Thunderbird Lightning Plugin](https://addons.thunderbird.net/en-US/thunderbird/addon/lightning/) (Cross Platform Desktop App)
+* [Thunderbird Lightning](https://www.thunderbird.net/en-US/calendar/) (Cross Platform Desktop App)
 * [Vdirsyncer](https://vdirsyncer.pimutils.org/en/stable/) (Linux)
 * [BusyCal](https://www.busymac.com/busycal) (MacOS)
 * [aCalendar+](https://acalendar.tapirapps.de/de/support/home) (via Davx5) [(Android)](https://play.google.com/store/apps/details?id=org.withouthat.acalendarplus)


### PR DESCRIPTION
The Thunderbird Lightning Plugin previously residing at [https://addons.thunderbird.net/en-US/thunderbird/addon/lightning/](https://addons.thunderbird.net/en-US/thunderbird/addon/lightning/) is no longer available. The functionality is however fully present and working in Thunderbird as is.
This PR changes the URL to a working one ([https://www.thunderbird.net/en-US/calendar/](https://www.thunderbird.net/en-US/calendar/)).