### PR TITLE
Don't break trashbin if calendar is undefined

### DIFF
--- a/src/components/AppNavigation/Trashbin.vue
+++ b/src/components/AppNavigation/Trashbin.vue
@@ -158,7 +158,7 @@ export default {
 				} catch (e) {
 					// ignore
 				}
-				let subline = vobject.calendar.displayName
+				let subline = vobject.calendar?.displayName || t('tasks', 'Unknown calendar')
 				if (vobject.isEvent) {
 					const event = vobject?.calendarComponent.getFirstComponent('VEVENT')
 					if (event?.startDate.jsDate && event?.isAllDay()) {
@@ -168,8 +168,8 @@ export default {
 					}
 				}
 				const color = vobject.calendarComponent.getComponentIterator().next().value?.color
-						?? vobject.calendar.color
-						?? uidToHexColor(vobject.calendar.displayName)
+						?? vobject.calendar?.color
+						?? uidToHexColor(subline)
 				return {
 					vobject,
 					type: 'object',


### PR DESCRIPTION
This currently only contains the first half of the fix. The trash bin will now properly load and show all deleted items. Deletion also works fine.

But, for deleted events from calendars that only support events (not tasks), `Unknown calendar` will be shown. This is because these calendars are not loaded by the Tasks app by default.

In order to make this work properly, we have to load _all_ calendars from the server when opening the trash bin. This also covers calendars that were newly created after the initial load of the app.

Closes #1803.