### PR TITLE
Always show sharing icon for shared lists

### DIFF
--- a/src/components/AppNavigation/ListItemCalendar.vue
+++ b/src/components/AppNavigation/ListItemCalendar.vue
@@ -555,11 +555,8 @@ $color-error: #e9322d;
 		margin: -1px;
 	}
 
-	&:not(.active) {
-		.app-navigation-entry__utils .action-item,
-		.calendar__share {
-			display: none;
-		}
+	&:not(.active) > .app-navigation-entry__utils .action-item:not(.shared) {
+		display: none;
 	}
 
 	&.list--edit {


### PR DESCRIPTION
With this PR the sharing icon for lists that are shared (with others) is always shown. Before it was only visible when the list was selected / active.

Before:
![Screenshot 2021-12-05 at 22-20-01 Tasks - Nextcloud](https://user-images.githubusercontent.com/2496460/144764369-0742880b-a12b-4cf1-a0e4-2231c5a76c33.png)

After:
![Screenshot 2021-12-05 at 22-18-12 Tasks - Nextcloud](https://user-images.githubusercontent.com/2496460/144764339-640640ea-cd25-41f1-9ce8-b73d644fc216.png)

Closes #1862.