### PR TITLE
Fix: Inconsistencies due to ALTREP parameter

### DIFF
--- a/src/models/task.js
+++ b/src/models/task.js
@@ -366,7 +366,7 @@ export default class Task {
 	}
 
 	set note(note) {
-		// To avoid inconsistent parameters, delete complete property, then recreate
+		// To avoid inconsistent property parameters (bug #3863 in nextcloud/calendar), delete the property, then recreate
 		this.vtodo.removeProperty('description')
 		this.vtodo.addPropertyWithValue('description', note)
 		this.updateLastModified()

--- a/src/models/task.js
+++ b/src/models/task.js
@@ -367,6 +367,7 @@ export default class Task {
 
 	set note(note) {
 		this.vtodo.updatePropertyWithValue('description', note)
+		this.vtodo.getFirstProperty('description').removeParameter('altrep')
 		this.updateLastModified()
 		this._note = this.vtodo.getFirstPropertyValue('description') || ''
 	}

--- a/src/models/task.js
+++ b/src/models/task.js
@@ -366,8 +366,9 @@ export default class Task {
 	}
 
 	set note(note) {
-		this.vtodo.updatePropertyWithValue('description', note)
-		this.vtodo.getFirstProperty('description').removeParameter('altrep')
+		// To avoid inconsistent parameters, delete complete property, then recreate
+		this.vtodo.removeProperty('description')
+		this.vtodo.addPropertyWithValue('description', note)
 		this.updateLastModified()
 		this._note = this.vtodo.getFirstPropertyValue('description') || ''
 	}


### PR DESCRIPTION
This PR addresses an inconsistency issue with Thunderbird. In addition to the plain text description of a task, Thunderbird also saves a formatted HTML version inside the ALTREP parameter. NC calendar does not alter the ALTREP parameter when the plain text description is changed. This results in inconsistencies.

The proposed solution deletes the ALTREP parameter upon modification. This prevents inconsistencies. Thunderbird keeps accepting plaintext-only descriptions.

I have opened a [similar PR](https://github.com/nextcloud/calendar/pull/3918) in nextcloud/calendar as it is equally concerned.