### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/src/components/TaskCheckbox.vue
+++ b/src/components/TaskCheckbox.vue
@@ -89,7 +89,7 @@ export default {
 			return 'checkbox-' + Math.random()
 				.toString(36)
 				.replace(/[^a-z]+/g, '')
-				.substr(0, 6)
+				.slice(0, 6)
 		},
 	},
 	methods: {

--- a/src/models/task.js
+++ b/src/models/task.js
@@ -193,7 +193,7 @@ export default class Task {
 	 */
 	get uri() {
 		if (this.dav) {
-			return this.dav.url.substr(this.dav.url.lastIndexOf('/') + 1)
+			return this.dav.url.slice(this.dav.url.lastIndexOf('/') + 1)
 		}
 		return ''
 	}

--- a/src/store/calendars.js
+++ b/src/store/calendars.js
@@ -145,7 +145,7 @@ export function mapDavShareeToSharee(sharee) {
 		: sharee.href
 
 	if (sharee.href.startsWith('principal:principals/groups/') && name === sharee.href) {
-		name = sharee.href.substr(28)
+		name = sharee.href.slice(28)
 	}
 
 	return {
@@ -375,7 +375,7 @@ const getters = {
 		const calendarUriMap = {}
 		state.calendars.forEach(calendar => {
 			const withoutTrail = calendar.url.replace(/\/$/, '')
-			const uri = withoutTrail.substr(withoutTrail.lastIndexOf('/') + 1)
+			const uri = withoutTrail.slice(withoutTrail.lastIndexOf('/') + 1)
 			calendarUriMap[uri] = calendar
 		})
 

--- a/src/talk.js
+++ b/src/talk.js
@@ -59,7 +59,7 @@ window.addEventListener('DOMContentLoaded', () => {
 		icon: 'icon-tasks',
 		async callback({ message: { message, actorDisplayName }, metadata: { name: conversationName, token: conversationToken } }) {
 			const shortenedMessageCandidate = message.replace(/^(.{255}[^\s]*).*/, '$1')
-			const shortenedMessage = shortenedMessageCandidate === '' ? message.substr(0, 255) : shortenedMessageCandidate
+			const shortenedMessage = shortenedMessageCandidate === '' ? message.slice(0, 255) : shortenedMessageCandidate
 			try {
 				await buildSelector(TaskCreateDialog, {
 					title: shortenedMessage,

--- a/src/utils/color.js
+++ b/src/utils/color.js
@@ -49,9 +49,9 @@ export function detectColor(color) {
 	} else if (/^((?:[A-Fa-f0-9]{3}){1,2})$/.test(color)) { // ff00ff and f0f
 		return '#' + color
 	} else if (/^(#)((?:[A-Fa-f0-9]{8}))$/.test(color)) { // #ff00ffff and #f0ff
-		return color.substr(0, 7)
+		return color.slice(0, 7)
 	} else if (/^((?:[A-Fa-f0-9]{8}))$/.test(color)) { // ff00ffff and f0ff
-		return '#' + color.substr(0, 6)
+		return '#' + color.slice(0, 6)
 	}
 
 	return false


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.