### PR TITLE
Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,9 @@ on:
       - master
       - stable*
 
+permissions:
+  contents: read
+
 jobs:
   php:
     runs-on: ubuntu-latest

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -7,6 +7,9 @@ on:
       - master
       - stable*
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
