### PR TITLE
Migrate to DashboardWidget from nextcloud/vue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
 				"@nextcloud/moment": "^1.2.1",
 				"@nextcloud/router": "^2.0.0",
 				"@nextcloud/vue": "^6.0.0-alpha.0",
-				"@nextcloud/vue-dashboard": "^2.0.1",
 				"color-convert": "^2.0.1",
 				"debounce": "^1.2.1",
 				"ical.js": "^1.5.0",
@@ -1559,28 +1558,6 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
-		"node_modules/@babel/polyfill": {
-			"version": "7.2.5",
-			"resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.2.5.tgz",
-			"integrity": "sha512-8Y/t3MWThtMLYr0YNC/Q76tqN1w30+b0uQMeFUYauG2UGTR19zyUtFrAzT23zNtBxPp+LbE5E/nwV/q/r3y6ug==",
-			"deprecated": "🚨 This package has been deprecated in favor of separate inclusion of a polyfill and regenerator-runtime (when needed). See the @babel/polyfill docs (https://babeljs.io/docs/en/babel-polyfill) for more information.",
-			"dependencies": {
-				"core-js": "^2.5.7",
-				"regenerator-runtime": "^0.12.0"
-			}
-		},
-		"node_modules/@babel/polyfill/node_modules/core-js": {
-			"version": "2.6.12",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-			"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-			"deprecated": "core-js@<3.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
-			"hasInstallScript": true
-		},
-		"node_modules/@babel/polyfill/node_modules/regenerator-runtime": {
-			"version": "0.12.1",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-			"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
-		},
 		"node_modules/@babel/preset-env": {
 			"version": "7.14.8",
 			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.14.8.tgz",
@@ -1685,19 +1662,6 @@
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
 			}
-		},
-		"node_modules/@babel/runtime": {
-			"version": "7.3.4",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.4.tgz",
-			"integrity": "sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==",
-			"dependencies": {
-				"regenerator-runtime": "^0.12.0"
-			}
-		},
-		"node_modules/@babel/runtime/node_modules/regenerator-runtime": {
-			"version": "0.12.1",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-			"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
 		},
 		"node_modules/@babel/template": {
 			"version": "7.16.7",
@@ -2928,177 +2892,6 @@
 				"npm": "^7.0.0"
 			}
 		},
-		"node_modules/@nextcloud/vue-dashboard": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue-dashboard/-/vue-dashboard-2.0.1.tgz",
-			"integrity": "sha512-eLzdK8Ey5rrs3D6i2OAA5jkZ6lklrAbfnRgL40tZLIJ+MEKvRuPOjwrzhJKxHgVp3rU1rEgkaaPvSNXRVGS1mQ==",
-			"dependencies": {
-				"@nextcloud/vue": "^3.1.1",
-				"core-js": "^3.6.4",
-				"vue": "^2.6.11"
-			},
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"@nextcloud/vue": "^3.1.1",
-				"vue": "^2.6.11"
-			}
-		},
-		"node_modules/@nextcloud/vue-dashboard/node_modules/@nextcloud/event-bus": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-1.3.0.tgz",
-			"integrity": "sha512-+U5MnCvfnNWvf0lvdqJg8F+Nm8wN+s9ayuBjtiEQxTAcootv7lOnlMgfreqF3l2T0Wet2uZh4JbFVUWf8l3w7g==",
-			"dependencies": {
-				"@types/semver": "^7.3.5",
-				"core-js": "^3.11.2",
-				"semver": "^7.3.5"
-			}
-		},
-		"node_modules/@nextcloud/vue-dashboard/node_modules/@nextcloud/router": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-1.2.0.tgz",
-			"integrity": "sha512-kn9QsL9LuhkIMaSSgdiqRL3SZ6PatuAjXUiyq343BbSnI99Oc5eJH8kU6cT2AHije7wKy/tK8Xe3VQuVO32SZQ==",
-			"dependencies": {
-				"core-js": "^3.6.4"
-			}
-		},
-		"node_modules/@nextcloud/vue-dashboard/node_modules/@nextcloud/vue": {
-			"version": "3.10.1",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-3.10.1.tgz",
-			"integrity": "sha512-DdnnEFxt5FuZOtAD1x7hSDFVQF9KVVgQtFKwzs2ySNbyIx8rfRfc6noC7JbMAPR1LyPegCst0bVwQIfqsASGog==",
-			"dependencies": {
-				"@nextcloud/auth": "^1.2.3",
-				"@nextcloud/axios": "^1.3.2",
-				"@nextcloud/browser-storage": "^0.1.1",
-				"@nextcloud/capabilities": "^1.0.2",
-				"@nextcloud/dialogs": "^3.0.0",
-				"@nextcloud/event-bus": "^1.1.4",
-				"@nextcloud/l10n": "^1.2.3",
-				"@nextcloud/router": "^1.0.2",
-				"core-js": "^3.6.5",
-				"debounce": "1.2.1",
-				"emoji-mart-vue-fast": "^7.0.7",
-				"escape-html": "^1.0.3",
-				"hammerjs": "^2.0.8",
-				"linkifyjs": "~2.1.9",
-				"md5": "^2.2.1",
-				"regenerator-runtime": "^0.13.5",
-				"string-length": "^4.0.1",
-				"striptags": "^3.1.1",
-				"style-loader": "^2.0.0",
-				"tributejs": "^5.1.3",
-				"v-click-outside": "^3.0.1",
-				"v-tooltip": "^2.0.3",
-				"vue": "^2.6.11",
-				"vue-color": "^2.7.1",
-				"vue-multiselect": "^2.1.6",
-				"vue-visible": "^1.0.2",
-				"vue2-datepicker": "^3.6.3"
-			},
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
-		"node_modules/@nextcloud/vue-dashboard/node_modules/char-regex": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
-			"integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@nextcloud/vue-dashboard/node_modules/loader-utils": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-			"integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
-			"dependencies": {
-				"big.js": "^5.2.2",
-				"emojis-list": "^3.0.0",
-				"json5": "^2.1.2"
-			},
-			"engines": {
-				"node": ">=8.9.0"
-			}
-		},
-		"node_modules/@nextcloud/vue-dashboard/node_modules/lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@nextcloud/vue-dashboard/node_modules/schema-utils": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-			"integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
-			"dependencies": {
-				"@types/json-schema": "^7.0.8",
-				"ajv": "^6.12.5",
-				"ajv-keywords": "^3.5.2"
-			},
-			"engines": {
-				"node": ">= 10.13.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/webpack"
-			}
-		},
-		"node_modules/@nextcloud/vue-dashboard/node_modules/semver": {
-			"version": "7.3.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@nextcloud/vue-dashboard/node_modules/string-length": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
-			"integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
-			"dependencies": {
-				"char-regex": "^1.0.2",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@nextcloud/vue-dashboard/node_modules/style-loader": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-2.0.0.tgz",
-			"integrity": "sha512-Z0gYUJmzZ6ZdRUqpg1r8GsaFKypE+3xAzuFeMuoHgjc9KZv3wMyCRjQIWEbhoFSq7+7yoHXySDJyyWQaPajeiQ==",
-			"dependencies": {
-				"loader-utils": "^2.0.0",
-				"schema-utils": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 10.13.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/webpack"
-			},
-			"peerDependencies": {
-				"webpack": "^4.0.0 || ^5.0.0"
-			}
-		},
-		"node_modules/@nextcloud/vue-dashboard/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-		},
 		"node_modules/@nextcloud/vue/node_modules/@babel/polyfill": {
 			"version": "7.12.1",
 			"resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
@@ -3445,7 +3238,8 @@
 		"node_modules/@types/json-schema": {
 			"version": "7.0.9",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-			"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
+			"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+			"peer": true
 		},
 		"node_modules/@types/json5": {
 			"version": "0.0.29",
@@ -4033,6 +3827,7 @@
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -4090,6 +3885,7 @@
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
 			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+			"peer": true,
 			"peerDependencies": {
 				"ajv": "^6.9.1"
 			}
@@ -4126,6 +3922,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -4575,6 +4372,8 @@
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
 			"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": "*"
 			}
@@ -6292,19 +6091,6 @@
 				"url": "https://github.com/sindresorhus/emittery?sponsor=1"
 			}
 		},
-		"node_modules/emoji-mart-vue-fast": {
-			"version": "7.0.7",
-			"resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-7.0.7.tgz",
-			"integrity": "sha512-Nrk4IOjKcKKYyMnRm4lreEiPpvDX+h3FKI86SYs05dCFZ0WZIMTGok26dtWvJqseTThS1UghsNEjM4HrfDjIJg==",
-			"dependencies": {
-				"@babel/polyfill": "7.2.5",
-				"@babel/runtime": "7.3.4",
-				"vue-virtual-scroller": "^1.0.0-rc.2"
-			},
-			"peerDependencies": {
-				"vue": "^2.0.0"
-			}
-		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -6315,6 +6101,8 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
 			"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 4"
 			}
@@ -7617,7 +7405,8 @@
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"peer": true
 		},
 		"node_modules/fast-glob": {
 			"version": "3.2.7",
@@ -10893,12 +10682,6 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
-		"node_modules/jquery": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-			"integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==",
-			"peer": true
-		},
 		"node_modules/js-beautify": {
 			"version": "1.14.0",
 			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.0.tgz",
@@ -11020,7 +10803,8 @@
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"peer": true
 		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
@@ -11033,6 +10817,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
 			"integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+			"dev": true,
 			"dependencies": {
 				"minimist": "^1.2.5"
 			},
@@ -11121,16 +10906,6 @@
 			"integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
 			"dependencies": {
 				"uc.micro": "^1.0.1"
-			}
-		},
-		"node_modules/linkifyjs": {
-			"version": "2.1.9",
-			"resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-2.1.9.tgz",
-			"integrity": "sha512-74ivurkK6WHvHFozVaGtQWV38FzBwSTGNmJolEgFp7QgR2bl6ArUWlvT4GcHKbPe1z3nWYi+VUdDZk16zDOVug==",
-			"peerDependencies": {
-				"jquery": ">= 1.11.0",
-				"react": ">= 0.14.0",
-				"react-dom": ">= 0.14.0"
 			}
 		},
 		"node_modules/loader-runner": {
@@ -11748,7 +11523,8 @@
 		"node_modules/minimist": {
 			"version": "1.2.6",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+			"dev": true
 		},
 		"node_modules/minimist-options": {
 			"version": "4.1.0",
@@ -12015,15 +11791,6 @@
 			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
 			"integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
 			"dev": true
-		},
-		"node_modules/object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-			"peer": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/object-inspect": {
 			"version": "1.12.2",
@@ -12915,33 +12682,6 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/react": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-			"integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-			"peer": true,
-			"dependencies": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/react-dom": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-			"integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-			"peer": true,
-			"dependencies": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1",
-				"scheduler": "^0.20.2"
-			},
-			"peerDependencies": {
-				"react": "17.0.2"
-			}
-		},
 		"node_modules/react-is": {
 			"version": "18.2.0",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
@@ -13345,16 +13085,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/scheduler": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-			"integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-			"peer": true,
-			"dependencies": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1"
 			}
 		},
 		"node_modules/schema-utils": {
@@ -14019,6 +13749,7 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
 			},
@@ -14875,6 +14606,7 @@
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"peer": true,
 			"dependencies": {
 				"punycode": "^2.1.0"
 			}
@@ -15265,11 +14997,6 @@
 			"peerDependencies": {
 				"vue": "^2.3.0"
 			}
-		},
-		"node_modules/vue-visible": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/vue-visible/-/vue-visible-1.0.2.tgz",
-			"integrity": "sha512-yaX2its9XAJKGuQqf7LsiZHHSkxsIK8rmCOQOvEGEoF41blKRK8qr9my4qYoD6ikdLss4n8tKqYBecmaY0+WJg=="
 		},
 		"node_modules/vue2-datepicker": {
 			"version": "3.9.1",
@@ -17078,27 +16805,6 @@
 				"@babel/helper-plugin-utils": "^7.14.5"
 			}
 		},
-		"@babel/polyfill": {
-			"version": "7.2.5",
-			"resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.2.5.tgz",
-			"integrity": "sha512-8Y/t3MWThtMLYr0YNC/Q76tqN1w30+b0uQMeFUYauG2UGTR19zyUtFrAzT23zNtBxPp+LbE5E/nwV/q/r3y6ug==",
-			"requires": {
-				"core-js": "^2.5.7",
-				"regenerator-runtime": "^0.12.0"
-			},
-			"dependencies": {
-				"core-js": {
-					"version": "2.6.12",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-					"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
-				},
-				"regenerator-runtime": {
-					"version": "0.12.1",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-					"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
-				}
-			}
-		},
 		"@babel/preset-env": {
 			"version": "7.14.8",
 			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.14.8.tgz",
@@ -17193,21 +16899,6 @@
 				"@babel/plugin-transform-dotall-regex": "^7.4.4",
 				"@babel/types": "^7.4.4",
 				"esutils": "^2.0.2"
-			}
-		},
-		"@babel/runtime": {
-			"version": "7.3.4",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.4.tgz",
-			"integrity": "sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==",
-			"requires": {
-				"regenerator-runtime": "^0.12.0"
-			},
-			"dependencies": {
-				"regenerator-runtime": {
-					"version": "0.12.1",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-					"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
-				}
 			}
 		},
 		"@babel/template": {
@@ -18205,134 +17896,6 @@
 				}
 			}
 		},
-		"@nextcloud/vue-dashboard": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue-dashboard/-/vue-dashboard-2.0.1.tgz",
-			"integrity": "sha512-eLzdK8Ey5rrs3D6i2OAA5jkZ6lklrAbfnRgL40tZLIJ+MEKvRuPOjwrzhJKxHgVp3rU1rEgkaaPvSNXRVGS1mQ==",
-			"requires": {
-				"@nextcloud/vue": "^3.1.1",
-				"core-js": "^3.6.4",
-				"vue": "^2.6.11"
-			},
-			"dependencies": {
-				"@nextcloud/event-bus": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-1.3.0.tgz",
-					"integrity": "sha512-+U5MnCvfnNWvf0lvdqJg8F+Nm8wN+s9ayuBjtiEQxTAcootv7lOnlMgfreqF3l2T0Wet2uZh4JbFVUWf8l3w7g==",
-					"requires": {
-						"@types/semver": "^7.3.5",
-						"core-js": "^3.11.2",
-						"semver": "^7.3.5"
-					}
-				},
-				"@nextcloud/router": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-1.2.0.tgz",
-					"integrity": "sha512-kn9QsL9LuhkIMaSSgdiqRL3SZ6PatuAjXUiyq343BbSnI99Oc5eJH8kU6cT2AHije7wKy/tK8Xe3VQuVO32SZQ==",
-					"requires": {
-						"core-js": "^3.6.4"
-					}
-				},
-				"@nextcloud/vue": {
-					"version": "3.10.1",
-					"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-3.10.1.tgz",
-					"integrity": "sha512-DdnnEFxt5FuZOtAD1x7hSDFVQF9KVVgQtFKwzs2ySNbyIx8rfRfc6noC7JbMAPR1LyPegCst0bVwQIfqsASGog==",
-					"requires": {
-						"@nextcloud/auth": "^1.2.3",
-						"@nextcloud/axios": "^1.3.2",
-						"@nextcloud/browser-storage": "^0.1.1",
-						"@nextcloud/capabilities": "^1.0.2",
-						"@nextcloud/dialogs": "^3.0.0",
-						"@nextcloud/event-bus": "^1.1.4",
-						"@nextcloud/l10n": "^1.2.3",
-						"@nextcloud/router": "^1.0.2",
-						"core-js": "^3.6.5",
-						"debounce": "1.2.1",
-						"emoji-mart-vue-fast": "^7.0.7",
-						"escape-html": "^1.0.3",
-						"hammerjs": "^2.0.8",
-						"linkifyjs": "~2.1.9",
-						"md5": "^2.2.1",
-						"regenerator-runtime": "^0.13.5",
-						"string-length": "^4.0.1",
-						"striptags": "^3.1.1",
-						"style-loader": "^2.0.0",
-						"tributejs": "^5.1.3",
-						"v-click-outside": "^3.0.1",
-						"v-tooltip": "^2.0.3",
-						"vue": "^2.6.11",
-						"vue-color": "^2.7.1",
-						"vue-multiselect": "^2.1.6",
-						"vue-visible": "^1.0.2",
-						"vue2-datepicker": "^3.6.3"
-					}
-				},
-				"char-regex": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
-					"integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw=="
-				},
-				"loader-utils": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-					"integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
-					"requires": {
-						"big.js": "^5.2.2",
-						"emojis-list": "^3.0.0",
-						"json5": "^2.1.2"
-					}
-				},
-				"lru-cache": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
-				"schema-utils": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-					"integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
-					"requires": {
-						"@types/json-schema": "^7.0.8",
-						"ajv": "^6.12.5",
-						"ajv-keywords": "^3.5.2"
-					}
-				},
-				"semver": {
-					"version": "7.3.5",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				},
-				"string-length": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
-					"integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
-					"requires": {
-						"char-regex": "^1.0.2",
-						"strip-ansi": "^6.0.0"
-					}
-				},
-				"style-loader": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-2.0.0.tgz",
-					"integrity": "sha512-Z0gYUJmzZ6ZdRUqpg1r8GsaFKypE+3xAzuFeMuoHgjc9KZv3wMyCRjQIWEbhoFSq7+7yoHXySDJyyWQaPajeiQ==",
-					"requires": {
-						"loader-utils": "^2.0.0",
-						"schema-utils": "^3.0.0"
-					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-				}
-			}
-		},
 		"@nextcloud/webpack-vue-config": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/@nextcloud/webpack-vue-config/-/webpack-vue-config-5.2.1.tgz",
@@ -18595,7 +18158,8 @@
 		"@types/json-schema": {
 			"version": "7.0.9",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-			"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
+			"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+			"peer": true
 		},
 		"@types/json5": {
 			"version": "0.0.29",
@@ -19105,6 +18669,7 @@
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"peer": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -19148,6 +18713,7 @@
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
 			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+			"peer": true,
 			"requires": {}
 		},
 		"ansi-escapes": {
@@ -19169,7 +18735,8 @@
 		"ansi-regex": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
@@ -19520,7 +19087,9 @@
 		"big.js": {
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-			"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
+			"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+			"dev": true,
+			"peer": true
 		},
 		"bluebird": {
 			"version": "3.7.2",
@@ -20904,16 +20473,6 @@
 			"integrity": "sha512-aITqOwnLanpHLNXZJENbOgjUBeHocD+xsSJmNrjovKBW5HbSpW3d1pEls7GFQPUWXiwG9+0P4GtHfEqC/4M0Iw==",
 			"dev": true
 		},
-		"emoji-mart-vue-fast": {
-			"version": "7.0.7",
-			"resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-7.0.7.tgz",
-			"integrity": "sha512-Nrk4IOjKcKKYyMnRm4lreEiPpvDX+h3FKI86SYs05dCFZ0WZIMTGok26dtWvJqseTThS1UghsNEjM4HrfDjIJg==",
-			"requires": {
-				"@babel/polyfill": "7.2.5",
-				"@babel/runtime": "7.3.4",
-				"vue-virtual-scroller": "^1.0.0-rc.2"
-			}
-		},
 		"emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -20923,7 +20482,9 @@
 		"emojis-list": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-			"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
+			"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+			"dev": true,
+			"peer": true
 		},
 		"encodeurl": {
 			"version": "1.0.2",
@@ -21893,7 +21454,8 @@
 		"fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"peer": true
 		},
 		"fast-glob": {
 			"version": "3.2.7",
@@ -24315,12 +23877,6 @@
 				}
 			}
 		},
-		"jquery": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-			"integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==",
-			"peer": true
-		},
 		"js-beautify": {
 			"version": "1.14.0",
 			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.0.tgz",
@@ -24411,7 +23967,8 @@
 		"json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"peer": true
 		},
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
@@ -24424,6 +23981,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
 			"integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+			"dev": true,
 			"requires": {
 				"minimist": "^1.2.5"
 			}
@@ -24492,12 +24050,6 @@
 			"requires": {
 				"uc.micro": "^1.0.1"
 			}
-		},
-		"linkifyjs": {
-			"version": "2.1.9",
-			"resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-2.1.9.tgz",
-			"integrity": "sha512-74ivurkK6WHvHFozVaGtQWV38FzBwSTGNmJolEgFp7QgR2bl6ArUWlvT4GcHKbPe1z3nWYi+VUdDZk16zDOVug==",
-			"requires": {}
 		},
 		"loader-runner": {
 			"version": "4.2.0",
@@ -25001,7 +24553,8 @@
 		"minimist": {
 			"version": "1.2.6",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+			"dev": true
 		},
 		"minimist-options": {
 			"version": "4.1.0",
@@ -25215,12 +24768,6 @@
 			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
 			"integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
 			"dev": true
-		},
-		"object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-			"peer": true
 		},
 		"object-inspect": {
 			"version": "1.12.2",
@@ -25893,27 +25440,6 @@
 				}
 			}
 		},
-		"react": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-			"integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-			"peer": true,
-			"requires": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1"
-			}
-		},
-		"react-dom": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-			"integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-			"peer": true,
-			"requires": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1",
-				"scheduler": "^0.20.2"
-			}
-		},
 		"react-is": {
 			"version": "18.2.0",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
@@ -26200,16 +25726,6 @@
 			"dev": true,
 			"requires": {
 				"xmlchars": "^2.2.0"
-			}
-		},
-		"scheduler": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-			"integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-			"peer": true,
-			"requires": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1"
 			}
 		},
 		"schema-utils": {
@@ -26769,6 +26285,7 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "^5.0.1"
 			}
@@ -27411,6 +26928,7 @@
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"peer": true,
 			"requires": {
 				"punycode": "^2.1.0"
 			}
@@ -27739,11 +27257,6 @@
 					"requires": {}
 				}
 			}
-		},
-		"vue-visible": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/vue-visible/-/vue-visible-1.0.2.tgz",
-			"integrity": "sha512-yaX2its9XAJKGuQqf7LsiZHHSkxsIK8rmCOQOvEGEoF41blKRK8qr9my4qYoD6ikdLss4n8tKqYBecmaY0+WJg=="
 		},
 		"vue2-datepicker": {
 			"version": "3.9.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
 		"@nextcloud/moment": "^1.2.1",
 		"@nextcloud/router": "^2.0.0",
 		"@nextcloud/vue": "^6.0.0-alpha.0",
-		"@nextcloud/vue-dashboard": "^2.0.1",
 		"color-convert": "^2.0.1",
 		"debounce": "^1.2.1",
 		"ical.js": "^1.5.0",

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -61,7 +61,8 @@ import { sort, isTaskInList } from '../store/storeHelper.js'
 
 import { translate as t } from '@nextcloud/l10n'
 import { generateUrl } from '@nextcloud/router'
-import { DashboardWidget, DashboardWidgetItem } from '@nextcloud/vue-dashboard'
+import DashboardWidget from '@nextcloud/vue/dist/Components/DashboardWidget'
+import DashboardWidgetItem from '@nextcloud/vue/dist/Components/DashboardWidgetItem'
 
 import { mapGetters, mapActions } from 'vuex'
 


### PR DESCRIPTION
After https://github.com/nextcloud/nextcloud-vue/pull/2668 is merged and released, we can migrate to the Dashboard components now living in nextcloud/vue.