### PR TITLE
Display tasks with future start date dimly

### DIFF
--- a/src/components/TaskBody.vue
+++ b/src/components/TaskBody.vue
@@ -656,16 +656,18 @@ $breakpoint-mobile: 1024px;
 		opacity: .6;
 	}
 
-	&--non-started .title {
-		color: var(--color-placeholder-dark);
-	}
+	&--non-started {
+		.title {
+			color: var(--color-placeholder-dark);
+		}
 
-	&--non-started > .task-item__body {
-		background-color: var(--color-background-dark);
-	}
+		> .task-item__body {
+			background-color: var(--color-background-dark);
+		}
 
-	&--non-started .task-checkbox {
-		opacity: .2;
+		.task-checkbox {
+			opacity: .2;
+		}
 	}
 
 	&.sortable-ghost {

--- a/src/components/TaskBody.vue
+++ b/src/components/TaskBody.vue
@@ -76,6 +76,7 @@ License along with this library. If not, see <http://www.gnu.org/licenses/>.
 					<span class="calendar__name">{{ task.calendar.displayName }}</span>
 				</div>
 				<SortVariant v-if="hasHiddenSubtasks" :size="20" :title="t('tasks', 'Task has hidden subtasks')" />
+				<CalendarClock v-if="!overdue(task.startMoment) && task.start" :size="20" :title="t('tasks', 'Task has not yet started')" />
 				<Pin v-if="task.pinned" :size="20" :title="t('tasks', 'Task is pinned')" />
 				<TextBoxOutline v-if="task.note!=''"
 					:size="20"
@@ -182,6 +183,7 @@ import Pin from 'vue-material-design-icons/Pin'
 import Plus from 'vue-material-design-icons/Plus'
 import TextBoxOutline from 'vue-material-design-icons/TextBoxOutline'
 import SortVariant from 'vue-material-design-icons/SortVariant'
+import CalendarClock from 'vue-material-design-icons/CalendarClock'
 import Star from 'vue-material-design-icons/Star'
 import Undo from 'vue-material-design-icons/Undo'
 
@@ -206,6 +208,7 @@ export default {
 		Plus,
 		TextBoxOutline,
 		SortVariant,
+		CalendarClock,
 		Star,
 		Undo,
 	},
@@ -655,14 +658,6 @@ $breakpoint-mobile: 1024px;
 
 	&--non-started .title {
 		color: var(--color-placeholder-dark);
-	}
-
-	&--non-started .title:before {
-		content: '⏱️';
-		font-style: normal;
-		position: absolute;
-		right: 5px;
-		top: 13px;
 	}
 
 	&--non-started > .task-item__body {

--- a/src/components/TaskBody.vue
+++ b/src/components/TaskBody.vue
@@ -673,7 +673,7 @@ $breakpoint-mobile: 1024px;
 	&--non-started .task-checkbox {
 		opacity: .2;
 	}
-	
+
 	&.sortable-ghost {
 		filter: drop-shadow(0 0 3px var(--color-primary));
 		z-index: 5;

--- a/src/components/TaskBody.vue
+++ b/src/components/TaskBody.vue
@@ -28,7 +28,8 @@ License along with this library. If not, see <http://www.gnu.org/licenses/>.
 			'task-item--closed': task.closed,
 			'task-item--deleted': task.deleteCountdown !== null,
 			'task-item--input-visible': (filteredSubtasksShown.length || showSubtaskInput),
-			'task-item--subtasks-visible': filteredSubtasksShown.length
+			'task-item--subtasks-visible': filteredSubtasksShown.length,
+			'task-item--non-started': !overdue(task.startMoment) && task.start
 		}"
 		:data-priority="[task.priority]"
 		class="task-item"
@@ -652,6 +653,27 @@ $breakpoint-mobile: 1024px;
 		opacity: .6;
 	}
 
+	&--non-started .title {
+		opacity: .7;
+		font-style: italic;
+	}
+
+	&--non-started .title:before {
+		content: '⏱️';
+		font-style: normal;
+		position: absolute;
+		right: 5px;
+		top: 13px;
+	}
+
+	&--non-started > .task-item__body {
+		opacity: .9;
+	}
+
+	&--non-started .task-checkbox {
+		opacity: .2;
+	}
+	
 	&.sortable-ghost {
 		filter: drop-shadow(0 0 3px var(--color-primary));
 		z-index: 5;

--- a/src/components/TaskBody.vue
+++ b/src/components/TaskBody.vue
@@ -658,11 +658,7 @@ $breakpoint-mobile: 1024px;
 
 	&--non-started {
 		.title {
-			color: var(--color-placeholder-dark);
-		}
-
-		> .task-item__body {
-			background-color: var(--color-background-dark);
+			color: var(--color-text-maxcontrast);
 		}
 
 		.task-checkbox {

--- a/src/components/TaskBody.vue
+++ b/src/components/TaskBody.vue
@@ -654,7 +654,7 @@ $breakpoint-mobile: 1024px;
 	}
 
 	&--non-started .title {
-		opacity: .7;
+		color: var(--color-placeholder-dark);
 		font-style: italic;
 	}
 
@@ -667,7 +667,7 @@ $breakpoint-mobile: 1024px;
 	}
 
 	&--non-started > .task-item__body {
-		opacity: .9;
+		background-color: var(--color-background-dark);
 	}
 
 	&--non-started .task-checkbox {

--- a/src/components/TaskBody.vue
+++ b/src/components/TaskBody.vue
@@ -655,7 +655,6 @@ $breakpoint-mobile: 1024px;
 
 	&--non-started .title {
 		color: var(--color-placeholder-dark);
-		font-style: italic;
 	}
 
 	&--non-started .title:before {


### PR DESCRIPTION
Render future tasks (tasks with a start date in the future) differently than other tasks : Lower opacity, little icon on the right. Italic text.

Before : 
![2022-05-09_23-04-05](https://user-images.githubusercontent.com/93337483/167498303-29325957-23cd-47c3-9e6f-9f02d09cfdd2.png)

After : 
![2022-05-10_10-49-08](https://user-images.githubusercontent.com/93337483/167589088-73d162e5-920e-4f5f-9af0-ce48269ed020.png)

![2022-05-10_10-50-22](https://user-images.githubusercontent.com/93337483/167589098-017a0514-f589-4a2e-a6a6-798ba61d82fb.png)


What changes :
![2022-05-10_10-49-35](https://user-images.githubusercontent.com/93337483/167589165-e887a61d-a863-48cc-a2fd-d4e3e8036b2d.png)

EDIT : After a few tweeks suggested by @raimund-schluessler, here's the result : 
![2022-05-12_14-12-25](https://user-images.githubusercontent.com/93337483/168106772-77f8ccb4-ee59-482d-9399-0b6bc04e7e52.png)
(no italic, better icon and alt text)



(This is the first time I make a PR. Hope I'm doing it right 🤞)

Thank you 😊