### PR TITLE
Don't show dashboard actions for readonly tasks

### DIFF
--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -34,13 +34,21 @@ License along with this library. If not, see <http://www.gnu.org/licenses/>.
 			<template #default="{ item }">
 				<DashboardWidgetItem :main-text="item.summary"
 					:sub-text="formatSubtext(item)"
-					:target-url="getTasksAppUrl(item)"
-					:item-menu="itemMenu"
-					@markAsDone="onMarkAsDone(item)">
+					:target-url="getTasksAppUrl(item)">
 					<template #avatar>
 						<div class="calendar-dot"
 							:style="{'background-color': item.calendar.color}"
 							:title="item.calendar.displayName" />
+					</template>
+					<template #actions>
+						<ActionButton v-if="!item.calendar.readOnly && !(item.calendar.isSharedWithMe && item.class !== 'PUBLIC')"
+							:close-after-click="true"
+							@click="onMarkAsDone(item)">
+							<template #icon>
+								<Check :size="20" decorative />
+							</template>
+							{{ t('tasks', 'Mark as done') }}
+						</ActionButton>
 					</template>
 				</DashboardWidgetItem>
 			</template>
@@ -61,14 +69,19 @@ import { sort, isTaskInList } from '../store/storeHelper.js'
 
 import { translate as t } from '@nextcloud/l10n'
 import { generateUrl } from '@nextcloud/router'
+import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
 import DashboardWidget from '@nextcloud/vue/dist/Components/DashboardWidget'
 import DashboardWidgetItem from '@nextcloud/vue/dist/Components/DashboardWidgetItem'
+
+import Check from 'vue-material-design-icons/Check'
 
 import { mapGetters, mapActions } from 'vuex'
 
 export default {
 	name: 'Dashboard',
 	components: {
+		ActionButton,
+		Check,
 		DashboardWidget,
 		DashboardWidgetItem,
 		TaskCreateDialog,


### PR DESCRIPTION
This PR prevents showing a non-functional mark-as-complete action for read only tasks in the Dashboard.

Requires #1985 and https://github.com/nextcloud/nextcloud-vue/pull/2718.

Before:
![Screenshot 2022-06-01 at 22-46-13 Dashboard - Nextcloud](https://user-images.githubusercontent.com/2496460/171499618-e0d317e1-5d83-429b-8349-490db357aa0a.png)

After:
![Screenshot 2022-06-01 at 22-54-37 Dashboard - Nextcloud](https://user-images.githubusercontent.com/2496460/171499777-c778e216-f203-4723-b374-22c65335a913.png)
