### PR TITLE
Adjust AppNavigation to new nextcloud/vue version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
 				"@nextcloud/logger": "^2.3.0",
 				"@nextcloud/moment": "^1.2.1",
 				"@nextcloud/router": "^2.0.0",
-				"@nextcloud/vue": "^6.0.0-beta.4",
+				"@nextcloud/vue": "^6.0.0-beta.7",
 				"color-convert": "^2.0.1",
 				"debounce": "^1.2.1",
 				"ical.js": "^1.5.0",
@@ -2884,9 +2884,9 @@
 			}
 		},
 		"node_modules/@nextcloud/vue": {
-			"version": "6.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-6.0.0-beta.4.tgz",
-			"integrity": "sha512-1TdzH0++/gIcBzot8iNT3AnweR/1EykpCfBwkJNhMgoiY4HlMLxBj7bpe2D4ul24XTCoXVEdGMYyB32GNVc9WA==",
+			"version": "6.0.0-beta.7",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-6.0.0-beta.7.tgz",
+			"integrity": "sha512-wRXnTSMm55CElCu5W0XUtMf32BmtMG4aiFAYDY9PpT19pru2blLXu0LzjVPNkRZ5bFISpp83H9YVYrNFbbkwBA==",
 			"dependencies": {
 				"@nextcloud/auth": "^2.0.0",
 				"@nextcloud/axios": "^2.0.0",
@@ -2895,6 +2895,7 @@
 				"@nextcloud/capabilities": "^1.0.4",
 				"@nextcloud/dialogs": "^3.1.4",
 				"@nextcloud/event-bus": "^3.0.0",
+				"@nextcloud/initial-state": "^2.0.0",
 				"@nextcloud/l10n": "^1.6.0",
 				"@nextcloud/logger": "^2.2.1",
 				"@nextcloud/router": "^2.0.0",
@@ -17913,9 +17914,9 @@
 			}
 		},
 		"@nextcloud/vue": {
-			"version": "6.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-6.0.0-beta.4.tgz",
-			"integrity": "sha512-1TdzH0++/gIcBzot8iNT3AnweR/1EykpCfBwkJNhMgoiY4HlMLxBj7bpe2D4ul24XTCoXVEdGMYyB32GNVc9WA==",
+			"version": "6.0.0-beta.7",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-6.0.0-beta.7.tgz",
+			"integrity": "sha512-wRXnTSMm55CElCu5W0XUtMf32BmtMG4aiFAYDY9PpT19pru2blLXu0LzjVPNkRZ5bFISpp83H9YVYrNFbbkwBA==",
 			"requires": {
 				"@nextcloud/auth": "^2.0.0",
 				"@nextcloud/axios": "^2.0.0",
@@ -17924,6 +17925,7 @@
 				"@nextcloud/capabilities": "^1.0.4",
 				"@nextcloud/dialogs": "^3.1.4",
 				"@nextcloud/event-bus": "^3.0.0",
+				"@nextcloud/initial-state": "^2.0.0",
 				"@nextcloud/l10n": "^1.6.0",
 				"@nextcloud/logger": "^2.2.1",
 				"@nextcloud/router": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"@nextcloud/logger": "^2.3.0",
 		"@nextcloud/moment": "^1.2.1",
 		"@nextcloud/router": "^2.0.0",
-		"@nextcloud/vue": "^6.0.0-beta.4",
+		"@nextcloud/vue": "^6.0.0-beta.7",
 		"color-convert": "^2.0.1",
 		"debounce": "^1.2.1",
 		"ical.js": "^1.5.0",

--- a/src/components/AppNavigation/CalendarSharee.vue
+++ b/src/components/AppNavigation/CalendarSharee.vue
@@ -25,7 +25,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <template>
-	<NcAppNavigationItem :title="sharee.displayName">
+	<NcAppNavigationItem :title="sharee.displayName" forceDisplayActions>
 		<template #icon>
 			<AccountMultiple v-if="sharee.isGroup"
 				:size="18"

--- a/src/components/AppNavigation/ListItemCalendar.vue
+++ b/src/components/AppNavigation/ListItemCalendar.vue
@@ -160,7 +160,7 @@ import Undo from 'vue-material-design-icons/Undo'
 import ClickOutside from 'v-click-outside'
 import { mapGetters, mapActions } from 'vuex'
 
-const CD_DURATION = 7
+const CD_DURATION = 700
 
 export default {
 	components: {
@@ -547,7 +547,7 @@ $color-error: #e9322d;
 		margin: -1px;
 	}
 
-	> div:not(.active) > .app-navigation-entry__utils .action-item:not(.shared) {
+	> div:not(.active) > .app-navigation-entry__utils .action-item.sharing:not(.shared) {
 		display: none;
 	}
 
@@ -569,6 +569,10 @@ $color-error: #e9322d;
 
 		.app-navigation-entry__icon-bullet {
 			opacity: .3;
+		}
+
+		.action-item.app-navigation-entry__actions {
+			display: inline-block;
 		}
 	}
 

--- a/src/components/AppNavigation/ListItemCalendar.vue
+++ b/src/components/AppNavigation/ListItemCalendar.vue
@@ -160,7 +160,7 @@ import Undo from 'vue-material-design-icons/Undo'
 import ClickOutside from 'v-click-outside'
 import { mapGetters, mapActions } from 'vuex'
 
-const CD_DURATION = 700
+const CD_DURATION = 7
 
 export default {
 	components: {


### PR DESCRIPTION
This adjusts the AppNavigation to the new version of nextcloud/vue. Requires https://github.com/nextcloud/nextcloud-vue/pull/3165 to work properly.