### PR TITLE
Fix copying to clipboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
 				"uuid": "^8.3.2",
 				"v-click-outside": "^3.2.0",
 				"vue": "^2.7.10",
-				"vue-clipboard2": "^0.3.3",
 				"vue-material-design-icons": "^5.1.2",
 				"vue-router": "^3.6.5",
 				"vuedraggable": "^2.24.3",
@@ -5031,16 +5030,6 @@
 			"resolved": "https://registry.npmjs.org/clamp/-/clamp-1.0.1.tgz",
 			"integrity": "sha512-kgMuFyE78OC6Dyu3Dy7vcx4uy97EIbVxJB/B0eJ3bUNAkwdNcxYzgKltnyADiYwsR7SEqkkUPsEUT//OVS6XMA=="
 		},
-		"node_modules/clipboard": {
-			"version": "2.0.11",
-			"resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.11.tgz",
-			"integrity": "sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==",
-			"dependencies": {
-				"good-listener": "^1.2.2",
-				"select": "^1.1.2",
-				"tiny-emitter": "^2.0.0"
-			}
-		},
 		"node_modules/cliui": {
 			"version": "7.0.4",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -5886,11 +5875,6 @@
 			"engines": {
 				"node": ">=0.4.0"
 			}
-		},
-		"node_modules/delegate": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-			"integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
 		},
 		"node_modules/depd": {
 			"version": "2.0.0",
@@ -8039,14 +8023,6 @@
 			"integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
 			"dev": true,
 			"peer": true
-		},
-		"node_modules/good-listener": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
-			"integrity": "sha512-goW1b+d9q/HIwbVYZzZ6SsTr4IgE+WA44A0GmPIQstuOrgsFcT7VEJ48nmr9GaRtNu0XTKacFLGnBPAM6Afouw==",
-			"dependencies": {
-				"delegate": "^3.1.2"
-			}
 		},
 		"node_modules/graceful-fs": {
 			"version": "4.2.10",
@@ -13110,11 +13086,6 @@
 			"resolved": "https://registry.npmjs.org/scrollparent/-/scrollparent-2.0.1.tgz",
 			"integrity": "sha512-HSdN78VMvFCSGCkh0oYX/tY4R3P1DW61f8+TeZZ4j2VLgfwvw0bpRSOv4PCVKisktIwbzHCfZsx+rLbbDBqIBA=="
 		},
-		"node_modules/select": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-			"integrity": "sha512-OwpTSOfy6xSs1+pwcNrv0RBMOzI39Lp3qQKUTPVVPRjCdNa5JH/oPRiqsesIskK8TVgmRiHwO4KXlV2Li9dANA=="
-		},
 		"node_modules/select-hose": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -14506,11 +14477,6 @@
 				"node": ">=0.6.0"
 			}
 		},
-		"node_modules/tiny-emitter": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-			"integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
-		},
 		"node_modules/tinycolor2": {
 			"version": "1.4.2",
 			"resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
@@ -14986,14 +14952,6 @@
 			"dependencies": {
 				"@vue/compiler-sfc": "2.7.10",
 				"csstype": "^3.1.0"
-			}
-		},
-		"node_modules/vue-clipboard2": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/vue-clipboard2/-/vue-clipboard2-0.3.3.tgz",
-			"integrity": "sha512-aNWXIL2DKgJyY/1OOeITwAQz1fHaCIGvUFHf9h8UcoQBG5a74MkdhS/xqoYe7DNZdQmZRL+TAdIbtUs9OyVjbw==",
-			"dependencies": {
-				"clipboard": "^2.0.0"
 			}
 		},
 		"node_modules/vue-color": {
@@ -19844,16 +19802,6 @@
 			"resolved": "https://registry.npmjs.org/clamp/-/clamp-1.0.1.tgz",
 			"integrity": "sha512-kgMuFyE78OC6Dyu3Dy7vcx4uy97EIbVxJB/B0eJ3bUNAkwdNcxYzgKltnyADiYwsR7SEqkkUPsEUT//OVS6XMA=="
 		},
-		"clipboard": {
-			"version": "2.0.11",
-			"resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.11.tgz",
-			"integrity": "sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==",
-			"requires": {
-				"good-listener": "^1.2.2",
-				"select": "^1.1.2",
-				"tiny-emitter": "^2.0.0"
-			}
-		},
 		"cliui": {
 			"version": "7.0.4",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -20518,11 +20466,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
-		},
-		"delegate": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-			"integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
 		},
 		"depd": {
 			"version": "2.0.0",
@@ -22153,14 +22096,6 @@
 			"integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
 			"dev": true,
 			"peer": true
-		},
-		"good-listener": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
-			"integrity": "sha512-goW1b+d9q/HIwbVYZzZ6SsTr4IgE+WA44A0GmPIQstuOrgsFcT7VEJ48nmr9GaRtNu0XTKacFLGnBPAM6Afouw==",
-			"requires": {
-				"delegate": "^3.1.2"
-			}
 		},
 		"graceful-fs": {
 			"version": "4.2.10",
@@ -25941,11 +25876,6 @@
 			"resolved": "https://registry.npmjs.org/scrollparent/-/scrollparent-2.0.1.tgz",
 			"integrity": "sha512-HSdN78VMvFCSGCkh0oYX/tY4R3P1DW61f8+TeZZ4j2VLgfwvw0bpRSOv4PCVKisktIwbzHCfZsx+rLbbDBqIBA=="
 		},
-		"select": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-			"integrity": "sha512-OwpTSOfy6xSs1+pwcNrv0RBMOzI39Lp3qQKUTPVVPRjCdNa5JH/oPRiqsesIskK8TVgmRiHwO4KXlV2Li9dANA=="
-		},
 		"select-hose": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -27025,11 +26955,6 @@
 				"setimmediate": "^1.0.4"
 			}
 		},
-		"tiny-emitter": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-			"integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
-		},
 		"tinycolor2": {
 			"version": "1.4.2",
 			"resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
@@ -27413,14 +27338,6 @@
 			"requires": {
 				"@vue/compiler-sfc": "2.7.10",
 				"csstype": "^3.1.0"
-			}
-		},
-		"vue-clipboard2": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/vue-clipboard2/-/vue-clipboard2-0.3.3.tgz",
-			"integrity": "sha512-aNWXIL2DKgJyY/1OOeITwAQz1fHaCIGvUFHf9h8UcoQBG5a74MkdhS/xqoYe7DNZdQmZRL+TAdIbtUs9OyVjbw==",
-			"requires": {
-				"clipboard": "^2.0.0"
 			}
 		},
 		"vue-color": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
 		"uuid": "^8.3.2",
 		"v-click-outside": "^3.2.0",
 		"vue": "^2.7.10",
-		"vue-clipboard2": "^0.3.3",
 		"vue-material-design-icons": "^5.1.2",
 		"vue-router": "^3.6.5",
 		"vuedraggable": "^2.24.3",

--- a/src/components/AppNavigation/ListItemCalendar.vue
+++ b/src/components/AppNavigation/ListItemCalendar.vue
@@ -426,7 +426,7 @@ export default {
 
 			// copy link for calendar to clipboard
 			try {
-				await this.$copyText(url)
+				await navigator.clipboard.writeText(url)
 				event.preventDefault()
 				this.copySuccess = true
 				this.copied = true

--- a/src/main.js
+++ b/src/main.js
@@ -40,8 +40,6 @@ import TrendingUp from 'vue-material-design-icons/TrendingUp.vue'
 
 import Vue from 'vue'
 import { sync } from 'vuex-router-sync'
-// eslint-disable-next-line import/no-named-as-default
-import VueClipboard from 'vue-clipboard2'
 
 // Disable on production
 Vue.config.devtools = true
@@ -59,8 +57,6 @@ __webpack_nonce__ = btoa(OC.requestToken)
 __webpack_public_path__ = linkTo('tasks', 'js/')
 
 sync(store, router)
-
-Vue.use(VueClipboard)
 
 /**
  * We have to globally register these material design icons


### PR DESCRIPTION
The currently used package `vue-clipboard2` has issues with the focus-trap of `NcActions` and seems anyway deprecated, given there is a native API for copying to the clipboard. This PR fixes the copy function and gets rid of the superfluous package.

See also https://github.com/nextcloud/nextcloud-vue/issues/3275.