### PR TITLE
Sort tasks by priority before sorting alphabetically

### DIFF
--- a/src/components/SortorderDropdown.vue
+++ b/src/components/SortorderDropdown.vue
@@ -113,32 +113,32 @@ export default {
 					id: 'start',
 					icon: 'CalendarStart',
 					text: t('tasks', 'Start date'),
-					hint: t('tasks', 'Sort by start date and summary.'),
+					hint: t('tasks', 'Sort by start date, priority and summary.'),
 				},
 				{
 					id: 'due',
 					icon: 'CalendarEnd',
 					text: t('tasks', 'Due date'),
-					hint: t('tasks', 'Sort by due date and summary.'),
+					hint: t('tasks', 'Sort by due date, priority and summary.'),
 				},
 				{
 					id: 'created',
 					icon: 'Plus',
 					// TRANSLATORS The date at which a task was created.
 					text: t('tasks', 'Created date'),
-					hint: t('tasks', 'Sort by created date and summary.'),
+					hint: t('tasks', 'Sort by created date, priority and summary.'),
 				},
 				{
 					id: 'modified',
 					icon: 'Pencil',
 					text: t('tasks', 'Last modified'),
-					hint: t('tasks', 'Sort by last-modified date and summary.'),
+					hint: t('tasks', 'Sort by last-modified date, priority and summary.'),
 				},
 				{
 					id: 'completedDate',
 					icon: 'Check',
 					text: t('tasks', 'Completed date'),
-					hint: t('tasks', 'Sort by completed date.'),
+					hint: t('tasks', 'Sort by completed date, priority and summary.'),
 				},
 				{
 					id: 'priority',

--- a/src/store/storeHelper.js
+++ b/src/store/storeHelper.js
@@ -237,23 +237,23 @@ function sort(tasks, sortOrder, sortDirection) {
 		break
 	}
 	case 'due': {
-		comparators = [sortByPinned, sortByDue, sortAlphabetically]
+		comparators = [sortByPinned, sortByDue, sortByPriority, sortAlphabetically]
 		break
 	}
 	case 'start': {
-		comparators = [sortByPinned, sortByStart, sortAlphabetically]
+		comparators = [sortByPinned, sortByStart, sortByPriority, sortAlphabetically]
 		break
 	}
 	case 'created': {
-		comparators = [sortByPinned, sortByCreated, sortAlphabetically]
+		comparators = [sortByPinned, sortByCreated, sortByPriority, sortAlphabetically]
 		break
 	}
 	case 'modified': {
-		comparators = [sortByPinned, sortByModified, sortAlphabetically]
+		comparators = [sortByPinned, sortByModified, sortByPriority, sortAlphabetically]
 		break
 	}
 	case 'completedDate': {
-		comparators = [sortByPinned, sortByCompletedDate, sortAlphabetically]
+		comparators = [sortByPinned, sortByCompletedDate, sortByPriority, sortAlphabetically]
 		break
 	}
 	case 'manual': {


### PR DESCRIPTION
This slightly changes the sort order of tasks to sort by priority before sorting alphabetically in case the main sort condition is equal for two tasks.

Closes #1369.