### PR TITLE
Don't block sort order dropdown by sidebar

### DIFF
--- a/src/components/SortorderDropdown.vue
+++ b/src/components/SortorderDropdown.vue
@@ -21,9 +21,7 @@ License along with this library. If not, see <http://www.gnu.org/licenses/>.
 
 <template>
 	<NcActions class="sortorder reactive"
-		:title="t('tasks', 'Change sort order')"
-		container=".header"
-		menu-align="right">
+		:title="t('tasks', 'Change sort order')">
 		<template #icon>
 			<span class="material-design-icon">
 				<component :is="sortOrderIcon" :size="20" />


### PR DESCRIPTION
Since Nextcloud 25 body does not scroll anymore, so there is no need to prevent attaching the dropdown to it anymore. Fixes the obstruction of the dropdown by the sidebar.