### PR TITLE
Update README.md: no subscription when downloaded via F-Droid

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Then open the Tasks app from the app menu.
 * [Davx5](https://www.davx5.com/) (Android)
 * [OpenTasks](https://opentasks.app/) [(Android)](https://play.google.com/store/apps/details?id=org.dmfs.tasks)
 * [Outlook Caldav Synchronizer](https://caldavsynchronizer.org/)  (Windows)
-* [Tasks: Astrid Todo List Clone](https://tasks.org/)  [(Android)](https://play.google.com/store/apps/details?id=org.tasks&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1) (Requires subscription)
+* [Tasks: Astrid Todo List Clone](https://tasks.org/)  [(Android)](https://play.google.com/store/apps/details?id=org.tasks&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1) (Requires subscription if not downloaded via F-Droid)
 * [Qownnotes](https://www.qownnotes.org/) (Read-only, Cross Platform Desktop App)
 * [Thunderbird Lightning](https://www.thunderbird.net/en-US/calendar/) (Cross Platform Desktop App)
 * [Vdirsyncer](https://vdirsyncer.pimutils.org/en/stable/) (Linux)


### PR DESCRIPTION
Apparently Tasks.org doesn't require a subscription to fully unlock all features if it's downloaded via F-Droid. https://tasks.org/docs/subscribe.html