### PR TITLE
Add proper labels to NcTextField components

### DIFF
--- a/src/components/AppNavigation/ListItemCalendar.vue
+++ b/src/components/AppNavigation/ListItemCalendar.vue
@@ -121,7 +121,7 @@ License along with this library. If not, see <http://www.gnu.org/licenses/>.
 					trailing-button-icon="arrowRight"
 					:value.sync="newCalendarName"
 					:error="nameError"
-					:placeholder="t('tasks', 'Save')"
+					:label="t('tasks', 'List name')"
 					@trailing-button-click="save(calendar)"
 					@keyup="checkName($event, calendar)">
 					<Pencil :size="16" />

--- a/src/views/AppNavigation.vue
+++ b/src/views/AppNavigation.vue
@@ -77,7 +77,7 @@ License along with this library. If not, see <http://www.gnu.org/licenses/>.
 							trailing-button-icon="arrowRight"
 							:value.sync="newCalendarName"
 							:error="nameError"
-							:placeholder="t('tasks', 'New List')"
+							:label="t('tasks', 'New list')"
 							@trailing-button-click="create()"
 							@keyup="checkName($event)">
 							<Plus :size="16" />


### PR DESCRIPTION
This adds proper labels to the `NcTextField` components. Will need https://github.com/nextcloud/nextcloud-vue/pull/3980 to work properly.