### PR TITLE
Remove p-queue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
 				"markdown-it-task-lists": "^2.1.1",
 				"md5": "^2.3.0",
 				"p-limit": "^4.0.0",
-				"p-queue": "^7.3.4",
 				"uuid": "^9.0.0",
 				"vue": "^2.7.14",
 				"vue-material-design-icons": "^5.2.0",
@@ -7948,7 +7947,9 @@
 		"node_modules/eventemitter3": {
 			"version": "4.0.7",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-			"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+			"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/events": {
 			"version": "3.3.0",
@@ -13016,21 +13017,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/p-queue": {
-			"version": "7.3.4",
-			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.4.tgz",
-			"integrity": "sha512-esox8CWt0j9EZECFvkFl2WNPat8LN4t7WWeXq73D9ha0V96qPRufApZi4ZhPwXAln1uVVal429HVVKPa2X0yQg==",
-			"dependencies": {
-				"eventemitter3": "^4.0.7",
-				"p-timeout": "^5.0.2"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/p-retry": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
@@ -13043,17 +13029,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/p-timeout": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
-			"integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/p-try": {
@@ -23219,7 +23194,9 @@
 		"eventemitter3": {
 			"version": "4.0.7",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-			"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+			"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+			"dev": true,
+			"peer": true
 		},
 		"events": {
 			"version": "3.3.0",
@@ -26892,15 +26869,6 @@
 				}
 			}
 		},
-		"p-queue": {
-			"version": "7.3.4",
-			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.4.tgz",
-			"integrity": "sha512-esox8CWt0j9EZECFvkFl2WNPat8LN4t7WWeXq73D9ha0V96qPRufApZi4ZhPwXAln1uVVal429HVVKPa2X0yQg==",
-			"requires": {
-				"eventemitter3": "^4.0.7",
-				"p-timeout": "^5.0.2"
-			}
-		},
 		"p-retry": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
@@ -26911,11 +26879,6 @@
 				"@types/retry": "0.12.0",
 				"retry": "^0.13.1"
 			}
-		},
-		"p-timeout": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
-			"integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew=="
 		},
 		"p-try": {
 			"version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
 		"markdown-it-task-lists": "^2.1.1",
 		"md5": "^2.3.0",
 		"p-limit": "^4.0.0",
-		"p-queue": "^7.3.4",
 		"uuid": "^9.0.0",
 		"vue": "^2.7.14",
 		"vue-material-design-icons": "^5.2.0",

--- a/src/models/task.js
+++ b/src/models/task.js
@@ -28,7 +28,6 @@ import moment from '@nextcloud/moment'
 
 import { v4 as uuid } from 'uuid'
 import ICAL from 'ical.js'
-import PQueue from 'p-queue'
 
 export default class Task {
 
@@ -66,10 +65,11 @@ export default class Task {
 		// Time in seconds before the task is going to be deleted
 		this.deleteCountdown = null
 
-		// Queue for update requests with concurrency 1,
-		// because we only want to allow one request at a time
+		// Flags if an update is currently running or scheduled,
+		// because we only want to allow one update at a time
 		// (otherwise we will run into problems with changed ETags).
-		this.updateQueue = new PQueue({ concurrency: 1 })
+		this.updateRunning = false
+		this.updateScheduled = false
 	}
 
 	initTodo() {

--- a/tests/javascript/unit/components/TaskDragContainer.spec.js
+++ b/tests/javascript/unit/components/TaskDragContainer.spec.js
@@ -36,8 +36,8 @@ describe('TaskDragContainer.vue', () => {
 
 	let store
 	beforeEach(() => {
-		// Override the "scheduleTaskUpdate" method so we don't get warnings about unresolved promises.
-		tasks.actions.scheduleTaskUpdate = jest.fn()
+		// Override the "updateTask" method so we don't get warnings about unresolved promises.
+		tasks.actions.updateTask = jest.fn()
 
 		store = new Store({
 			modules: {


### PR DESCRIPTION
This PR removes the `p-queue` dependency. It does not work (well) with vue3 proxy usage (since it uses private members) and is also not really needed / brings more features then necessary. This also reduces the bundle size by 10 kByte.