### PR TITLE
Use the color-primary-element* variables

### DIFF
--- a/src/components/TaskBody.vue
+++ b/src/components/TaskBody.vue
@@ -679,7 +679,7 @@ $breakpoint-mobile: 1024px;
 	}
 
 	&.sortable-ghost {
-		filter: drop-shadow(0 0 3px var(--color-primary));
+		filter: drop-shadow(0 0 3px var(--color-primary-element));
 		z-index: 5;
 	}
 
@@ -762,7 +762,7 @@ $breakpoint-mobile: 1024px;
 		}
 
 		&--active {
-			background-color: var(--color-primary-light) !important;
+			background-color: var(--color-primary-element-light) !important;
 		}
 
 		.task-body {

--- a/src/views/AppNavigation.vue
+++ b/src/views/AppNavigation.vue
@@ -453,8 +453,8 @@ $color-error: #e9322d;
 .app-navigation li {
 	&.dnd-hover,
 	&.sortable-ghost {
-		background-color: var(--color-primary-light);
-		box-shadow: 0 0 3px var(--color-primary);
+		background-color: var(--color-primary-element-light);
+		box-shadow: 0 0 3px var(--color-primary-element);
 		z-index: 1000;
 	}
 }


### PR DESCRIPTION
Explanation: the color-primary variables are not to be used in components because the introduce problems with high-contrast primary colors. Fix this by using the primary-element variables instead.