### PR TITLE
fix: missing tasks icon in talk app

### DIFF
--- a/css/tasks-talk.css
+++ b/css/tasks-talk.css
@@ -1,0 +1,9 @@
+.icon-tasks {
+	background-image: url(../img/tasks-dark.svg);
+	filter: var(--background-invert-if-dark);
+}
+
+.icon-tasks-white, .icon-tasks.icon-white {
+	background-image: url(../img/tasks.svg);
+	filter: var(--background-invert-if-dark);
+}

--- a/css/tasks-talk.scss
+++ b/css/tasks-talk.scss
@@ -1,1 +1,0 @@
-@include icon-black-white('tasks', 'tasks', 1);


### PR DESCRIPTION
This fixes the missing tasks icon in the talk app and the failing request to `tasks-talk.css`.

Closes #2351.