### PR TITLE
fix: don't set percent to 0 for NEEDS-ACTION

### DIFF
--- a/src/models/task.js
+++ b/src/models/task.js
@@ -346,8 +346,10 @@ export default class Task {
 				this.setComplete(1)
 			}
 		} else if (status === 'NEEDS-ACTION' || status === null) {
-			this.setComplete(0)
 			this.setCompleted(false)
+			if (this.complete === 100) {
+				this.setComplete(99)
+			}
 		}
 	}
 

--- a/tests/javascript/unit/models/task.spec.js
+++ b/tests/javascript/unit/models/task.spec.js
@@ -39,14 +39,24 @@ describe('task', () => {
 		expect(task.completedDate).not.toEqual(null)
 	})
 
-	it('Should set complete to 0 when status is "NEEDS-ACTION".', () => {
+	it('Should set complete to <100 when status is "NEEDS-ACTION".', () => {
 		const task = new Task(loadICS('vcalendars/vcalendar-default'), {})
 		task.complete = 100
 		task.status = 'NEEDS-ACTION'
-		expect(task.complete).toEqual(0)
-		// Check that property gets removed instead of being set to zero
+		expect(task.complete).toBeLessThan(100)
 		const complete = task.vtodo.getFirstPropertyValue('percent-complete')
-		expect(complete).toEqual(null)
+		expect(complete).toEqual(99)
+		expect(task.completed).toEqual(false)
+		expect(task.completedDate).toEqual(null)
+	})
+
+	it('Should not adjust complete when not completed and status is "NEEDS-ACTION".', () => {
+		const task = new Task(loadICS('vcalendars/vcalendar-default'), {})
+		task.complete = 90
+		task.status = 'NEEDS-ACTION'
+		expect(task.complete).toBeLessThan(100)
+		const complete = task.vtodo.getFirstPropertyValue('percent-complete')
+		expect(complete).toEqual(90)
 		expect(task.completed).toEqual(false)
 		expect(task.completedDate).toEqual(null)
 	})
@@ -213,7 +223,7 @@ describe('task', () => {
 		expect(complete).toEqual(null)
 	})
 
-	it('Indicates cloesed when completed or cancelled', () => {
+	it('Indicates closed when completed or cancelled', () => {
 		const task = new Task(loadICS('vcalendars/vcalendar-default'), {})
 		task.status = 'CANCELLED'
 		expect(task.closed).toEqual(true)


### PR DESCRIPTION
With this PR, the `percent-complete` value is not set to zero anymore, when the status is removed or set to `NEEDS-ACTION`. However, when the task is completed, and the status is set to `NEEDS-ACTION`, the `percent-complete` value is set to `99`.

Closes #2335.