### PR TITLE
feat: extract tags from task summary

### DIFF
--- a/src/store/storeHelper.js
+++ b/src/store/storeHelper.js
@@ -449,6 +449,27 @@ function searchSubTasks(task, searchQuery) {
 	})
 }
 
+/**
+ * Parses a string to extract tags and a summary
+ *
+ * @param {string} str The string
+ * @return {object} The object containing the parsed results
+ */
+function parseString(str) {
+	const matches = str.matchAll(/\s?#([^\s#]+)/g)
+	let summary = str
+	const tags = []
+	for (const match of matches) {
+	  tags.push(match[1])
+	  summary = summary.replace(match[0], '')
+	}
+	summary = summary.trim()
+	return {
+		summary,
+		tags,
+	}
+}
+
 export {
 	isTaskInList,
 	overdue,
@@ -456,4 +477,5 @@ export {
 	sort,
 	momentToICALTime,
 	searchSubTasks,
+	parseString,
 }

--- a/src/store/tasks.js
+++ b/src/store/tasks.js
@@ -23,7 +23,7 @@
 
 import { Calendar } from './calendars.js'
 import { findVTODObyUid } from './cdav-requests.js'
-import { isParentInList, momentToICALTime } from './storeHelper.js'
+import { isParentInList, momentToICALTime, parseString } from './storeHelper.js'
 import SyncStatus from '../models/syncStatus.js'
 import Task from '../models/task.js'
 
@@ -703,8 +703,11 @@ const actions = {
 		}
 		const task = new Task('BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//Nextcloud Tasks v' + appVersion + '\nEND:VCALENDAR', taskData.calendar)
 
+		const parsed = parseString(taskData.summary)
+
 		task.created = ICAL.Time.now()
-		task.summary = taskData.summary
+		task.summary = parsed.summary
+		task.tags = parsed.tags
 		task.hidesubtasks = 0
 		if (taskData.priority) {
 			task.priority = taskData.priority

--- a/tests/javascript/unit/store/storeHelper.spec.js
+++ b/tests/javascript/unit/store/storeHelper.spec.js
@@ -1,4 +1,4 @@
-import { sort } from '../../../../src/store/storeHelper.js'
+import { sort, parseString } from '../../../../src/store/storeHelper.js'
 import Task from '../../../../src/models/task.js'
 
 import { loadICS } from '../../../assets/loadAsset.js'
@@ -14,7 +14,7 @@ const vCalendarNames = [
 
 const tasks = vCalendarNames.map((vCalendar) => { return new Task(loadICS(vCalendar)) })
 
-describe('storeHelper', () => {
+describe('storeHelper - sort', () => {
 	'use strict'
 
 	it('Tests descending sort by due date.', () => {
@@ -29,5 +29,33 @@ describe('storeHelper', () => {
 		const expectedTasks = [tasks[2], tasks[0], tasks[1], tasks[3]]
 		const receivedTasks = sort(clonedTasks, 'due', 1)
 		expect(receivedTasks).toEqual(expectedTasks)
+	})
+})
+
+describe('storeHelper - parseString', () => {
+	'use strict'
+
+	it('returns the whole summary if no delimiters are present', () => {
+		const summary = 'plain summary without special delimiters'
+		const result = parseString(summary)
+		expect(result).toEqual({ summary, tags: [] })
+	})
+
+	it('returns the summary and single tag found', () => {
+		const summary = 'summary and #tag'
+		const result = parseString(summary)
+		expect(result).toEqual({ summary: 'summary and', tags: ['tag'] })
+	})
+
+	it('returns the summary and multiple tags found', () => {
+		const summary = 'summary and #tag1 #tag2'
+		const result = parseString(summary)
+		expect(result).toEqual({ summary: 'summary and', tags: ['tag1', 'tag2'] })
+	})
+
+	it('returns the summary and multiple tags found in varying order', () => {
+		const summary = '#tag1 summary and #tag2 #tag3 more summary #tag4'
+		const result = parseString(summary)
+		expect(result).toEqual({ summary: 'summary and more summary', tags: ['tag1', 'tag2', 'tag3', 'tag4'] })
 	})
 })


### PR DESCRIPTION
This PR adds automatic tagging by using hashtags in the task input field. A string like `Task title #tag1 #tasks #work` will create a task with the title `Task title` and the tags `['tag1', 'tasks', 'work']`.

Further extractions like setting the priority or due date can be easily added by enhancing the `parseString` function.

Related to #89. Fixes #42. Supersedes #1836.