### PR TITLE
feat: unify the appearance of tags in task body with sidebar

### DIFF
--- a/src/components/TaskBody.vue
+++ b/src/components/TaskBody.vue
@@ -818,6 +818,10 @@ $breakpoint-mobile: 1024px;
 
 		&--active {
 			background-color: var(--color-primary-element-light) !important;
+
+			.tag {
+				background-color: var(--color-main-background) !important;
+			}
 		}
 
 		.task-body {
@@ -857,19 +861,17 @@ $breakpoint-mobile: 1024px;
 					max-width: 50%;
 
 					.tag {
-						height: 22px;
+						height: 32px;
 						overflow: hidden;
-						display: inline-flex;
-						min-width: 45px;
-						background-color: var(--color-background-dark);
-						border: 1px solid var(--color-border-dark);
-						border-radius: 2px;
-						margin: 0 4px;
+						display: flex;
+						padding: 0 8px 0 12px;
+						background-color: var(--color-primary-element-light);
+						border: none;
+						border-radius: 18px !important;
+						margin: 4px 2px;
+						align-items: center;
 
 						.tag-label {
-							color: var(--color-text-lighter);
-							font-weight: bold;
-							padding: 2px 4px;
 							text-overflow: ellipsis;
 							overflow: hidden;
 							white-space: nowrap;


### PR DESCRIPTION
This unifies the style of the tags in the task body with the ones in the sidebar rendered by `NcSelect`.

Before:
![Screenshot 2023-12-31 at 10-51-24 Aufgaben - Nextcloud](https://github.com/nextcloud/tasks/assets/2496460/fb2eeb10-8801-46bb-9c73-57f6299e499f)

After:
![Screenshot 2023-12-31 at 10-48-33 Aufgaben - Nextcloud](https://github.com/nextcloud/tasks/assets/2496460/8a47bc2f-9a01-4058-888b-2836485d2230)
