### PR TITLE
fix: correctly show task body corners when tasks are hidden

### DIFF
--- a/src/components/TaskBody.vue
+++ b/src/components/TaskBody.vue
@@ -21,7 +21,7 @@ License along with this library. If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <template>
-	<li v-show="showTask"
+	<li v-if="showTask"
 		ref="taskItem"
 		:task-id="task.uri"
 		:class="{


### PR DESCRIPTION
Task body corner might not show up correctly when tasks are filtered. This is because the tasks are still in the DOM and the CSS selectors `:last-child` and `:first-child` do not work as expected then. Not rendering the tasks at all fixes this.