### PR TITLE
fix: allow to clear global search in filter menu

### DIFF
--- a/src/components/FilterDropdown.vue
+++ b/src/components/FilterDropdown.vue
@@ -82,14 +82,15 @@ export default {
 		...mapGetters({
 			tags: 'tags',
 			filter: 'filter',
+			searchQuery: 'searchQuery',
 		}),
 		isFilterActive() {
-			return this.filter.tags.length
+			return this.filter.tags.length || this.searchQuery
 		},
 	},
 	methods: {
 		t,
-		...mapMutations(['setFilter']),
+		...mapMutations(['setFilter', 'setSearchQuery']),
 
 		setTags(tags) {
 			const filter = this.filter
@@ -99,6 +100,7 @@ export default {
 
 		resetFilter() {
 			this.setFilter({ tags: [] })
+			this.setSearchQuery('')
 		},
 	},
 }


### PR DESCRIPTION
Since there currently is no way to reset the global search once anything was typed into it, we add the possibility to clear the search in the filter menu.

Before, the only way was to reload the page. @jancborchardt @skjnldsv Is this by design? Should I create an issue in the server repo for this (or this there already one I didn't find)?