### PR TITLE
fix: use TagMultiple icon consistently

### DIFF
--- a/src/components/AppSidebar/TagsItem.vue
+++ b/src/components/AppSidebar/TagsItem.vue
@@ -51,13 +51,13 @@ import MultiselectOption from './MultiselectOption.vue'
 import { translate as t } from '@nextcloud/l10n'
 import NcSelect from '@nextcloud/vue/dist/Components/NcSelect.js'
 
-import Tag from 'vue-material-design-icons/Tag.vue'
+import TagMultiple from 'vue-material-design-icons/TagMultiple.vue'
 
 export default {
 	components: {
 		NcSelect,
 		MultiselectOption,
-		Tag,
+		TagMultiple,
 	},
 	props: {
 		tags: {

--- a/src/main.js
+++ b/src/main.js
@@ -33,7 +33,6 @@ import Delete from 'vue-material-design-icons/Delete.vue'
 import Eye from 'vue-material-design-icons/Eye.vue'
 import EyeOff from 'vue-material-design-icons/EyeOff.vue'
 import Pulse from 'vue-material-design-icons/Pulse.vue'
-import Tag from 'vue-material-design-icons/Tag.vue'
 import TrendingUp from 'vue-material-design-icons/TrendingUp.vue'
 
 import Vue from 'vue'
@@ -66,8 +65,6 @@ Vue.component('IconEye', Eye)
 Vue.component('IconEyeOff', EyeOff)
 // eslint-disable-next-line vue/match-component-file-name
 Vue.component('IconPulse', Pulse)
-// eslint-disable-next-line vue/match-component-file-name
-Vue.component('IconTag', Tag)
 // eslint-disable-next-line vue/match-component-file-name
 Vue.component('IconTrendingUp', TrendingUp)
 

--- a/src/views/AppSidebar.vue
+++ b/src/views/AppSidebar.vue
@@ -188,7 +188,7 @@ License along with this library. If not, see <http://www.gnu.org/licenses/>.
 					:tags="task.tags"
 					:disabled="readOnly"
 					:placeholder="t('tasks', 'Select tags')"
-					icon="IconTag"
+					icon="TagMultiple"
 					@add-tag="updateTag"
 					@set-tags="updateTags" />
 			</div>


### PR DESCRIPTION
We use the `TagMultiple` icon now consistently, as it is the icon for tags used in Nextcloud.