### PR TITLE
feat: sort tags in dropdown alphabetically

### DIFF
--- a/src/store/tasks.js
+++ b/src/store/tasks.js
@@ -295,7 +295,7 @@ const getters = {
 				}
 			})
 			return tags
-		}, [])
+		}, []).sort((a, b) => a.localeCompare(b, 'en', { sensitivity: 'base' }))
 	},
 }
 


### PR DESCRIPTION
Orders the list of tags in the selection dropdown alphabetically.

Closes #2383.