### PR TITLE
fix: import TaskBody globally

### DIFF
--- a/src/components/TaskDragContainer.vue
+++ b/src/components/TaskDragContainer.vue
@@ -41,23 +41,9 @@ import { sort } from '../store/storeHelper.js'
 import draggable from 'vuedraggable'
 import { mapGetters, mapActions, mapMutations } from 'vuex'
 
-import { defineAsyncComponent } from 'vue'
-
-/**
- * We asynchronously import here, because we have a circular dependency
- * between TaskDragContainer and TaskBody which otherwise cannot be resolved.
- * See https://vuejs.org/guide/components/async.html#basic-usage
- *
- * @return {object} The TaskBody component
- */
-const TaskBody = defineAsyncComponent(() =>
-	import('./TaskBody.vue'),
-)
-
 export default {
 	name: 'TaskDragContainer',
 	components: {
-		TaskBody,
 		draggable,
 	},
 	props: {

--- a/src/main.js
+++ b/src/main.js
@@ -24,6 +24,7 @@
 import App from './App.vue'
 import router from './router.js'
 import store from './store/store.js'
+import TaskBody from './components/TaskBody.vue'
 
 import AlertBoxOutline from 'vue-material-design-icons/AlertBoxOutline.vue'
 import CalendarRemove from 'vue-material-design-icons/CalendarRemove.vue'
@@ -67,6 +68,13 @@ Vue.component('IconEyeOff', EyeOff)
 Vue.component('IconPulse', Pulse)
 // eslint-disable-next-line vue/match-component-file-name
 Vue.component('IconTrendingUp', TrendingUp)
+
+/**
+ * We import TaskBody here globally, because we have a circular dependency
+ * between TaskDragContainer and TaskBody which otherwise cannot be resolved.
+ */
+// eslint-disable-next-line vue/match-component-file-name
+Vue.component('TaskBody', TaskBody)
 
 if (!OCA.Tasks) {
 	/**

--- a/tests/javascript/unit/views/AppContent/General.spec.js
+++ b/tests/javascript/unit/views/AppContent/General.spec.js
@@ -1,11 +1,15 @@
 import General from '../../../../../src/views/AppContent/General.vue'
 import router from '../../../../../src/router.js'
+import TaskBody from '../../../../../src/components/TaskBody.vue'
 
 import { store, localVue } from '../../setupStore.js'
 
 import { mount } from '@vue/test-utils'
 
 import { describe, expect, it, vi } from 'vitest'
+
+import Vue from 'vue'
+Vue.component('TaskBody', TaskBody)
 
 describe('General.vue', async () => {
 	'use strict'

--- a/tests/javascript/unit/views/AppContent/Week.spec.js
+++ b/tests/javascript/unit/views/AppContent/Week.spec.js
@@ -1,11 +1,15 @@
 import Week from '../../../../../src/views/AppContent/Week.vue'
 import router from '../../../../../src/router.js'
+import TaskBody from '../../../../../src/components/TaskBody.vue'
 
 import { store, localVue } from '../../setupStore.js'
 
 import { mount } from '@vue/test-utils'
 
 import { describe, expect, it, vi } from 'vitest'
+
+import Vue from 'vue'
+Vue.component('TaskBody', TaskBody)
 
 describe('Week.vue', async () => {
 	'use strict'


### PR DESCRIPTION
This fixes the import of `TaskBody`. Using `defineAsyncComponent` worked on my dev environment, but not on production. The component would simply not render, without any warning or error in the console. I couldn't figure out what caused this, but importing it globally fixes the issue.

It makes testing components requiring `TaskBody` a bit awkward, though.

@susnux @ShGKme In case you have an idea, let me know :slightly_smiling_face: 