### PR TITLE
fix: load missing CSS file

### DIFF
--- a/templates/main.php
+++ b/templates/main.php
@@ -2,3 +2,4 @@
 
 script('tasks', 'tasks-main');
 style('tasks', 'tasks-main');
+style('tasks', 'tasks-store');


### PR DESCRIPTION
This loads a CSS file that was missing.
It is somehow a bit unfortunate, that vite builds multiple CSS files per entry point, instead of a single one.