### PR TITLE
fix: correctly handle timezones

### DIFF
--- a/src/store/storeHelper.js
+++ b/src/store/storeHelper.js
@@ -446,9 +446,9 @@ function sortByDeletedAt(taskA, taskB) {
  */
 function momentToICALTime(moment, asDate) {
 	if (asDate) {
-		return ICAL.Time.fromDateString(moment.format('YYYY-MM-DD'))
+		return ICAL.Time.fromJSDate(moment.toDate(), true)
 	} else {
-		return ICAL.Time.fromDateTimeString(moment.format('YYYY-MM-DDTHH:mm:ss'))
+		return ICAL.Time.fromJSDate(moment.toDate(), true)
 	}
 }
 

--- a/src/store/tasks.js
+++ b/src/store/tasks.js
@@ -755,7 +755,7 @@ const actions = {
 
 		const parsed = parseString(taskData.summary)
 
-		task.created = ICAL.Time.now()
+		task.created = ICAL.Time.fromJSDate(new Date(), true)
 		task.summary = parsed.summary
 		task.tags = parsed.tags
 		task.hidesubtasks = 0


### PR DESCRIPTION
This PR improves the timezone support for all dates (start, due, last-modified, completed, created). Datetimes are now parsed respecting their timezones and datetimes are written back to the database in the UTC timezone.

The PR also fixes an issue that occurred when toggling the all-day property. The dates shown did sometimes not resemble the date written to the server.

Closes #1233 and #1987.