### PR TITLE
fix: correctly set start and due date, toggle all-day

### DIFF
--- a/src/models/task.js
+++ b/src/models/task.js
@@ -535,7 +535,7 @@ export default class Task {
 				startJs.setHours(0)
 				this.setStart(ICAL.Time.fromJSDate(startJs, true))
 			} else {
-				this.setStart(start)
+				this.setStart(ICAL.Time.fromDateString(this._startMoment.format('YYYY-MM-DD')))
 			}
 		}
 		const due = this.vtodo.getFirstPropertyValue('due')
@@ -547,7 +547,7 @@ export default class Task {
 				dueJs.setHours(0)
 				this.setDue(ICAL.Time.fromJSDate(dueJs, true))
 			} else {
-				this.setDue(due)
+				this.setDue(ICAL.Time.fromDateString(this._dueMoment.format('YYYY-MM-DD')))
 			}
 		}
 	}

--- a/src/store/storeHelper.js
+++ b/src/store/storeHelper.js
@@ -446,7 +446,7 @@ function sortByDeletedAt(taskA, taskB) {
  */
 function momentToICALTime(moment, asDate) {
 	if (asDate) {
-		return ICAL.Time.fromJSDate(moment.toDate(), true)
+		return ICAL.Time.fromDateString(moment.format('YYYY-MM-DD'))
 	} else {
 		return ICAL.Time.fromJSDate(moment.toDate(), true)
 	}

--- a/src/views/AppSidebar.vue
+++ b/src/views/AppSidebar.vue
@@ -789,14 +789,14 @@ export default {
 		 * @param {Task} context.task The task for which to set the date
 		 * @param {Date} context.value The new start date
 		 */
-		setStartDate({ task, value: date }) {
-			if (date) {
-				date = moment(date)
+		setStartDate({ task, value: start }) {
+			if (start) {
+				start = moment(start)
 			}
-			if (this.task.startMoment.isSame(date)) {
+			if (this.task.startMoment.isSame(start)) {
 				return
 			}
-			this.setStart({ task, start: date, allDay: this.allDay })
+			this.setStart({ task, start, allDay: this.allDay })
 		},
 
 		/**
@@ -807,14 +807,14 @@ export default {
 		 * @param {Task} context.task The task for which to set the date
 		 * @param {Date} context.value The new due date
 		 */
-		setDueDate({ task, value: date }) {
-			if (date) {
-				date = moment(date)
+		setDueDate({ task, value: due }) {
+			if (due) {
+				due = moment(due)
 			}
-			if (this.task.dueMoment.isSame(date)) {
+			if (this.task.dueMoment.isSame(due)) {
 				return
 			}
-			this.setDue({ task, due: date, allDay: this.allDay })
+			this.setDue({ task, due, allDay: this.allDay })
 		},
 
 		changeClass(classification) {


### PR DESCRIPTION
This PR fixes setting the start and due dates and toggling between all-day and date-time.

- [x] Fix setting all-day dates
- [x] Toggling all-day setting moves dates into the past