### PR TITLE
feat: use web history mode

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -21,10 +21,29 @@
  */
 return [
 	'routes' => [
-		['name' => 'page#index',				'url' => '/',													'verb' => 'GET'],
-		['name' => 'collections#getCollections','url' => '/collections',										'verb' => 'GET'],
-		['name' => 'collections#setVisibility',	'url' => '/collection/{collectionID}/visibility/{visibility}',	'verb' => 'POST'],
-		['name' => 'settings#get',				'url' => '/settings',											'verb' => 'GET'],
-		['name' => 'settings#set',				'url' => '/settings/{setting}',									'verb' => 'POST'],
+		['name' => 'page#index',				'url' => '/',				'verb' => 'GET'],
+		['name' => 'page#index',				'url' => '/calendars',	'verb' => 'GET', 'postfix' => 'view.calendars'],
+		['name' => 'page#index',				'url' => '/calendars/',	'verb' => 'GET', 'postfix' => 'view.calendars./'],
+		[
+			'name' => 'page#index',
+			'url' => '/calendars/{calendar}',
+			'verb' => 'GET',
+			'postfix' => 'view.calendars.calendar',
+			'requirements' => array('calendar' => '.+')
+		],
+		['name' => 'page#index',				'url' => '/collections',	'verb' => 'GET', 'postfix' => 'view.collections'],
+		['name' => 'page#index',				'url' => '/collections/',	'verb' => 'GET', 'postfix' => 'view.collections./'],
+		[
+			'name' => 'page#index',
+			'url' => '/collections/{collection}',
+			'verb' => 'GET',
+			'postfix' => 'view.collections.collection',
+			'requirements' => array('collection' => '.+')
+		],
+
+		['name' => 'collections#getCollections','url' => '/api/v1/collections',										'verb' => 'GET'],
+		['name' => 'collections#setVisibility',	'url' => '/api/v1/collection/{collectionID}/visibility/{visibility}',	'verb' => 'POST'],
+		['name' => 'settings#get',				'url' => '/api/v1/settings',									'verb' => 'GET'],
+		['name' => 'settings#set',				'url' => '/api/v1/settings/{setting}',							'verb' => 'POST'],
 	]
 ];

--- a/src/router.js
+++ b/src/router.js
@@ -25,8 +25,16 @@ import AppSidebar from './views/AppSidebar.vue'
 import Calendar from './views/AppContent/Calendar.vue'
 import Collections from './views/AppContent/Collections.vue'
 
+import { getRootUrl, generateUrl } from '@nextcloud/router'
+
 import { h } from 'vue'
-import { createWebHashHistory, createRouter, RouterView } from 'vue-router'
+import { createWebHistory, createRouter, RouterView } from 'vue-router'
+
+const webRootWithIndexPHP = getRootUrl() + '/index.php'
+const doesURLContainIndexPHP = window.location.pathname.startsWith(webRootWithIndexPHP)
+const base = generateUrl('apps/tasks', {}, {
+	noRewrite: doesURLContainIndexPHP,
+})
 
 const routes = [
 	{ path: '/', redirect: getInitialRoute() },
@@ -81,7 +89,7 @@ const routes = [
 ]
 
 const router = createRouter({
-	history: createWebHashHistory(),
+	history: createWebHistory(base),
 	routes,
 })
 

--- a/src/store/collections.js
+++ b/src/store/collections.js
@@ -103,7 +103,7 @@ const actions = {
 	 */
 	loadCollections({ commit }) {
 		return new Promise(function(resolve) {
-			Requests.get(generateUrl('apps/tasks/collections'))
+			Requests.get(generateUrl('apps/tasks/api/v1/collections'))
 				.then(response => {
 					commit('setCollections', {
 						collections: response.data.data.collections,
@@ -123,7 +123,7 @@ const actions = {
 	setVisibility(context, collection) {
 		context.commit('setVisibility', collection)
 		return new Promise(function() {
-			Requests.post(generateUrl('apps/tasks/collection/{id}/visibility/{show}', collection), {})
+			Requests.post(generateUrl('apps/tasks/api/v1/collection/{id}/visibility/{show}', collection), {})
 		})
 	},
 }

--- a/src/store/settings.js
+++ b/src/store/settings.js
@@ -118,7 +118,7 @@ const actions = {
 	setSetting(context, payload) {
 		context.commit('setSetting', payload)
 		return new Promise(function() {
-			Requests.post(generateUrl('apps/tasks/settings/{type}', payload), { value: payload.value })
+			Requests.post(generateUrl('apps/tasks/api/v1/settings/{type}', payload), { value: payload.value })
 		})
 	},
 


### PR DESCRIPTION
This PR switches from `createWebHashHistory` to `createWebHistory`. This also fixes the skip-actions buttons, which did not work with `createWebHashHistory` mode.

A drawback is that current bookmarks to a certain collection or calendar won't work anymore and have to be recreated/adjusted.

Closes #2474.