### PR TITLE
fix: don't use ancient router version for nextcloud vue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3852,11 +3852,16 @@
       }
     },
     "node_modules/@nextcloud/vue/node_modules/@nextcloud/router": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-2.0.0.tgz",
-      "integrity": "sha512-GyHYNYrYAZRBGD5VxRggcbahdJ/zCkXb8+ERVfuaosT+nHMjJSmenTD6Uyct41qGm0p3Az4xRCXGyZGJM0NEUQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-2.2.1.tgz",
+      "integrity": "sha512-ZRc/WI0RaksEJMz08H/6LimIdP+1A1xTHThCYEghs7VgAKNp5917vT2OKSpG0cMRbIwk0ongFVt5FB5qjy/iFg==",
       "dependencies": {
+        "@nextcloud/typings": "^1.7.0",
         "core-js": "^3.6.4"
+      },
+      "engines": {
+        "node": "^20.0.0",
+        "npm": "^10.0.0"
       }
     },
     "node_modules/@nicolo-ribaudo/chokidar-2": {


### PR DESCRIPTION
The dependency resolution of `nextcloud/router` for `nextcloud/vue` was a bit off, causing the usage of an ancient router version. Introduced in #2479.