### PR TITLE
Add planify task manager to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Then open the Tasks app from the app menu.
 * [GNOME Todo](https://wiki.gnome.org/Apps/Todo) (via [GNOME Online Accounts](https://wiki.gnome.org/Design/SystemSettings/OnlineAccounts)) (Linux)
 * [Kalendar](https://apps.kde.org/kalendar/) (Linux)
 * [vdirsyncer](https://vdirsyncer.pimutils.org/en/stable/) (Linux and BSD)
+* [Planify](https://github.com/alainm23/planify/releases) (Linux)
 
 
 ## ETag (or: problem with non-existing conflicts)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Then open the Tasks app from the app menu.
 * [GNOME Todo](https://wiki.gnome.org/Apps/Todo) (via [GNOME Online Accounts](https://wiki.gnome.org/Design/SystemSettings/OnlineAccounts)) (Linux)
 * [Kalendar](https://apps.kde.org/kalendar/) (Linux)
 * [vdirsyncer](https://vdirsyncer.pimutils.org/en/stable/) (Linux and BSD)
-* [Planify](https://github.com/alainm23/planify/releases) (Linux)
+* [planify](https://github.com/alainm23/planify) (Linux)
 
 
 ## ETag (or: problem with non-existing conflicts)


### PR DESCRIPTION
In my opinion planify is currently the best and most fully featured task editor on on linux that is capable of supporting caldav. I would like to add it to the readme so that more people become aware of it.