### PR TITLE
feat: require caldav backend

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,6 +21,7 @@
     <screenshot>https://raw.githubusercontent.com/nextcloud/tasks/master/screenshots/tasks-1.png</screenshot>
     <dependencies>
         <nextcloud min-version="28" max-version="31"/>
+        <backend>caldav</backend>
     </dependencies>
     <navigations>
         <navigation>


### PR DESCRIPTION
Will be required after https://github.com/nextcloud/server/pull/46510
See also https://github.com/nextcloud/documentation/pull/12048

- [x] Wait for https://github.com/nextcloud/appstore/pull/1414 (to pass validation)

## Context

The CalDAV server settings for admins will be hidden if no app requires the CalDAV backend. Apps should require the backend via `info.xml`.

Please let me know if you have any further questions or feedback.