### PR TITLE
fix: adjust to changed counter bubble behavior

### DIFF
--- a/src/components/AppNavigation/ListItemCalendar.vue
+++ b/src/components/AppNavigation/ListItemCalendar.vue
@@ -48,9 +48,7 @@ License along with this library. If not, see <http://www.gnu.org/licenses/>.
 			</NcActions>
 			<NcAvatar v-if="calendar.isSharedWithMe && loadedOwnerPrincipal" :user="ownerUserId" :display-name="ownerDisplayname" />
 			<div v-if="calendar.isSharedWithMe && !loadedOwnerPrincipal" class="icon icon-loading" />
-			<NcCounterBubble v-if="calendarCount">
-				{{ counterFormatter(calendarCount) }}
-			</NcCounterBubble>
+			<NcCounterBubble v-if="calendarCount" :count="calendarCount" />
 		</template>
 
 		<template v-if="!deleteTimeout" #actions>
@@ -298,21 +296,6 @@ export default {
 			'moveTask',
 		]),
 
-		/**
-		 * Format the task counter
-		 *
-		 * @param {number} count The number of tasks
-		 */
-		counterFormatter(count) {
-			switch (false) {
-			case count !== 0:
-				return ''
-			case count < 999:
-				return '999+'
-			default:
-				return count
-			}
-		},
 		/**
 		 * Handle the drag over
 		 *

--- a/src/views/AppNavigation.vue
+++ b/src/views/AppNavigation.vue
@@ -42,9 +42,7 @@ License along with this library. If not, see <http://www.gnu.org/licenses/>.
 						:size="20" />
 				</template>
 				<template #counter>
-					<NcCounterBubble v-show="collectionCount(collection.id)">
-						{{ counterFormatter(collectionCount(collection.id)) }}
-					</NcCounterBubble>
+					<NcCounterBubble v-show="collectionCount(collection.id)" :count="collectionCount(collection.id)" />
 				</template>
 			</NcAppNavigationItem>
 			<Sortable class="draggable-container"
@@ -185,22 +183,6 @@ export default {
 			'setSetting',
 			'setCalendarOrder',
 		]),
-
-		/**
-		 * Format the task counter
-		 *
-		 * @param {number} count The number of tasks
-		 */
-		counterFormatter(count) {
-			switch (false) {
-			case count !== 0:
-				return ''
-			case count < 999:
-				return '999+'
-			default:
-				return count
-			}
-		},
 
 		/**
 		 * Indicate that we drag a calendar item


### PR DESCRIPTION
This PR adjusts the usage of `NcCounterBubble`. Requires a new release of the `@nextcloud/vue` components.