### PR TITLE
fix: correctly save and create reminders

### DIFF
--- a/src/components/AppSidebar/Alarm/AlarmList.vue
+++ b/src/components/AppSidebar/Alarm/AlarmList.vue
@@ -103,7 +103,7 @@ export default {
 			const valarm = {
 				action: 'DISPLAY',
 				// When the action is "DISPLAY", the alarm MUST also include a "DESCRIPTION" property
-				description: t('tasks', 'This is an event reminder.'),
+				description: t('tasks', 'This is a todo reminder.'),
 				// The "REPEAT" property is only valid in combination with a "DURATION" propery
 				repeat: 1,
 				duration: 'PT10M',

--- a/src/components/AppSidebar/Alarm/AlarmList.vue
+++ b/src/components/AppSidebar/Alarm/AlarmList.vue
@@ -104,7 +104,9 @@ export default {
 				action: 'DISPLAY',
 				// When the action is "DISPLAY", the alarm MUST also include a "DESCRIPTION" property
 				description: t('tasks', 'This is an event reminder.'),
+				// The "REPEAT" property is only valid in combination with a "DURATION" propery
 				repeat: 1,
+				duration: 'PT10M',
 				trigger: { value: undefined, parameter },
 			}
 

--- a/src/models/task.js
+++ b/src/models/task.js
@@ -593,11 +593,14 @@ export default class Task {
 	 *
 	 * @param {{ action: "AUDIO"|"DISPLAY"|"EMAIL"|"PROCEDURE", repeat: number, trigger: { value: ICAL.Duration|ICAL.Time, parameter: object }}} alarm The alarm
 	 */
-	addAlarm({ action, description, repeat, trigger }) {
+	addAlarm({ action, description, duration, repeat, trigger }) {
 		const valarm = new ICAL.Component('valarm')
 		valarm.addPropertyWithValue('action', action)
 		valarm.addPropertyWithValue('description', description)
-		valarm.addPropertyWithValue('repeat', repeat)
+		if (repeat > 1) {
+			valarm.addPropertyWithValue('repeat', repeat)
+			valarm.addPropertyWithValue('duration', duration)
+		}
 		const triggerProperty = valarm.addPropertyWithValue('trigger', trigger.value)
 		if (trigger.parameter) {
 			triggerProperty.setParameter(trigger.parameter.name, trigger.parameter.value)

--- a/src/models/task.js
+++ b/src/models/task.js
@@ -585,7 +585,7 @@ export default class Task {
 	}
 
 	getAlarms() {
-		return this.vCalendar.getAllSubcomponents('valarm') || []
+		return this.vtodo.getAllSubcomponents('valarm') || []
 	}
 
 	/**
@@ -601,14 +601,14 @@ export default class Task {
 		if (trigger.parameter) {
 			triggerProperty.setParameter(trigger.parameter.name, trigger.parameter.value)
 		}
-		this.vCalendar.addSubcomponent(valarm)
+		this.vtodo.addSubcomponent(valarm)
 
 		this.updateLastModified()
 		this._alarms = this.getAlarms()
 	}
 
 	updateAlarm({ action, repeat, trigger }, index) {
-		const valarms = this.vCalendar.getAllSubcomponents('valarm')
+		const valarms = this.vtodo.getAllSubcomponents('valarm')
 		const valarmToUpdate = valarms[index]
 
 		if (valarmToUpdate) {
@@ -625,11 +625,11 @@ export default class Task {
 	 * @param {number} index The index of the alarm-list
 	 */
 	removeAlarm(index) {
-		const valarms = this.vCalendar.getAllSubcomponents('valarm')
+		const valarms = this.vtodo.getAllSubcomponents('valarm')
 		const valarmToDelete = valarms[index]
 
 		if (valarmToDelete) {
-			this.vCalendar.removeSubcomponent(valarms[index])
+			this.vtodo.removeSubcomponent(valarms[index])
 
 			this.updateLastModified()
 			this._alarms = this.getAlarms()

--- a/src/models/task.js
+++ b/src/models/task.js
@@ -593,9 +593,10 @@ export default class Task {
 	 *
 	 * @param {{ action: "AUDIO"|"DISPLAY"|"EMAIL"|"PROCEDURE", repeat: number, trigger: { value: ICAL.Duration|ICAL.Time, parameter: object }}} alarm The alarm
 	 */
-	addAlarm({ action, repeat, trigger }) {
+	addAlarm({ action, description, repeat, trigger }) {
 		const valarm = new ICAL.Component('valarm')
 		valarm.addPropertyWithValue('action', action)
+		valarm.addPropertyWithValue('description', description)
 		valarm.addPropertyWithValue('repeat', repeat)
 		const triggerProperty = valarm.addPropertyWithValue('trigger', trigger.value)
 		if (trigger.parameter) {


### PR DESCRIPTION
This PR fixes a couple of issues with creating and saving reminders:

- `VALARM` is now a child of `VTODO`
- an alarm of action type `DISPLAY` now has a `DESCRIPTION`
- the `REPEAT` property of an alarm is now only set in combination with `DURATION` (and if repeat is > 1)
- the default description was slightly adjusted

Closes #2757 and makes alarms compatible with other apps following RFC 5545.