### PR TITLE
chore: fix all linter warnings

### DIFF
--- a/src/components/AppNavigation/Colorpicker.vue
+++ b/src/components/AppNavigation/Colorpicker.vue
@@ -65,7 +65,7 @@ export default {
 			default: '#31CC7C',
 		},
 	},
-	emits: ['color-selected'],
+	emits: ['colorSelected'],
 	data() {
 		return {
 			random: '#31CC7C',
@@ -92,7 +92,7 @@ export default {
 			this.pick(this.random)
 		},
 		pick(color) {
-			this.$emit('color-selected', color)
+			this.$emit('colorSelected', color)
 		},
 		/*
 		* Generate a random colour with the core generator

--- a/src/components/AppSidebar/Alarm/AlarmDateTimePickerModal.vue
+++ b/src/components/AppSidebar/Alarm/AlarmDateTimePickerModal.vue
@@ -52,7 +52,7 @@ export default {
 		},
 	},
 	emits: [
-		'select-date-time',
+		'selectDateTime',
 		'close',
 	],
 	data() {
@@ -72,7 +72,7 @@ export default {
 		},
 
 		onSubmit() {
-			this.$emit('select-date-time', this.date)
+			this.$emit('selectDateTime', this.date)
 		},
 
 		onClose() {

--- a/src/components/AppSidebar/Alarm/AlarmList.vue
+++ b/src/components/AppSidebar/Alarm/AlarmList.vue
@@ -71,9 +71,9 @@ export default {
 		},
 	},
 	emits: [
-		'add-alarm',
-		'remove-alarm',
-		'update-alarm',
+		'addAlarm',
+		'removeAlarm',
+		'updateAlarm',
 	],
 	computed: {
 		alarmComponents() {
@@ -125,7 +125,7 @@ export default {
 		 * @param {object} alarm The alarm time or duration
 		 */
 		addAlarm(alarm) {
-			this.$emit('add-alarm', this.generateVAlarm(alarm))
+			this.$emit('addAlarm', this.generateVAlarm(alarm))
 		},
 
 		/**
@@ -135,7 +135,7 @@ export default {
 		 * @param {number} index This index of the updated alarm-item
 		 */
 		updateAlarm(alarm, index) {
-			this.$emit('update-alarm', this.generateVAlarm(alarm), index)
+			this.$emit('updateAlarm', this.generateVAlarm(alarm), index)
 		},
 
 		/**
@@ -144,7 +144,7 @@ export default {
 		 * @param {number} index The index of the alarm-list
 		 */
 		removeAlarm(index) {
-			this.$emit('remove-alarm', index)
+			this.$emit('removeAlarm', index)
 		},
 	},
 }

--- a/src/components/AppSidebar/Alarm/AlarmListItem.vue
+++ b/src/components/AppSidebar/Alarm/AlarmListItem.vue
@@ -124,8 +124,8 @@ export default {
 		},
 	},
 	emits: [
-		'remove-alarm',
-		'update-alarm',
+		'removeAlarm',
+		'updateAlarm',
 	],
 	data() {
 		return {
@@ -210,7 +210,7 @@ export default {
 				parameter: undefined, // ical.js sets the correct parameter for us when using a `ICAL.Time`-object
 			}
 
-			this.$emit('update-alarm', alarm, this.index)
+			this.$emit('updateAlarm', alarm, this.index)
 			this.closeEditMode()
 		},
 
@@ -220,7 +220,7 @@ export default {
 				parameter: undefined, // We don't care about the params, since they currently can't be changed
 			}
 
-			this.$emit('update-alarm', alarm, this.index)
+			this.$emit('updateAlarm', alarm, this.index)
 			this.closeEditMode()
 		},
 
@@ -232,7 +232,7 @@ export default {
 		 * This method emits the removeAlarm event
 		 */
 		removeAlarm() {
-			this.$emit('remove-alarm', this.index)
+			this.$emit('removeAlarm', this.index)
 			this.showMenu = false
 		},
 	},

--- a/src/components/AppSidebar/Alarm/AlarmListNew.vue
+++ b/src/components/AppSidebar/Alarm/AlarmListNew.vue
@@ -137,7 +137,7 @@ export default {
 		},
 	},
 	emits: [
-		'add-alarm',
+		'addAlarm',
 	],
 	data() {
 		return {
@@ -214,7 +214,7 @@ export default {
 		},
 
 		onAlarmOptionClick(alarm) {
-			this.$emit('add-alarm', alarm)
+			this.$emit('addAlarm', alarm)
 		},
 
 		onChooseDateAndTime(date) {
@@ -223,7 +223,7 @@ export default {
 				parameter: undefined, // ical.js sets the correct parameter for us when using a `ICAL.Time`-object
 			}
 
-			this.$emit('add-alarm', alarm)
+			this.$emit('addAlarm', alarm)
 			this.chooseDateTimeMenuIsOpen = false
 		},
 	},

--- a/src/components/AppSidebar/Alarm/AlarmRelativeTimePickerModal.vue
+++ b/src/components/AppSidebar/Alarm/AlarmRelativeTimePickerModal.vue
@@ -85,7 +85,7 @@ export default {
 		},
 	},
 	emits: [
-		'select-date-time',
+		'selectDateTime',
 		'close',
 	],
 	data() {
@@ -149,7 +149,7 @@ export default {
 
 			const alarmObject = getAlarmObjectFromTriggerTime(seconds, this.alarm.relativeIsRelatedToStart)
 
-			this.$emit('select-date-time', alarmObject)
+			this.$emit('selectDateTime', alarmObject)
 		},
 
 		onClose() {

--- a/src/components/AppSidebar/CalendarPickerItem.vue
+++ b/src/components/AppSidebar/CalendarPickerItem.vue
@@ -73,7 +73,7 @@ export default {
 			required: false,
 		},
 	},
-	emits: ['change-calendar'],
+	emits: ['changeCalendar'],
 	computed: {
 		isDisabled() {
 			return this.calendars.length < 2 || this.disabled
@@ -108,7 +108,7 @@ export default {
 			if (!calendar) {
 				return
 			}
-			this.$emit('change-calendar', calendar)
+			this.$emit('changeCalendar', calendar)
 		},
 	},
 }

--- a/src/components/AppSidebar/CheckboxItem.vue
+++ b/src/components/AppSidebar/CheckboxItem.vue
@@ -28,7 +28,7 @@ License along with this library. If not, see <http://www.gnu.org/licenses/>.
 			:aria-checked="checked"
 			:checked="checked"
 			:disabled="readOnly"
-			@click="$emit('set-checked', checked)">
+			@click="$emit('setChecked', checked)">
 		<label :for="id">
 			<span>{{ propertyString }}</span>
 		</label>
@@ -56,7 +56,7 @@ export default {
 			default: '',
 		},
 	},
-	emits: ['set-checked'],
+	emits: ['setChecked'],
 }
 </script>
 

--- a/src/components/AppSidebar/DateTimePickerItem.vue
+++ b/src/components/AppSidebar/DateTimePickerItem.vue
@@ -121,7 +121,7 @@ export default {
 		checkOverdue: {
 			type: Boolean,
 			default: true,
-		}
+		},
 	},
 	data() {
 		return {

--- a/src/components/AppSidebar/MultiselectItem.vue
+++ b/src/components/AppSidebar/MultiselectItem.vue
@@ -86,7 +86,7 @@ export default {
 			default: null,
 		},
 	},
-	emits: ['change-value'],
+	emits: ['changeValue'],
 	computed: {
 		isDisabled() {
 			return this.options.length < 2 || this.disabled
@@ -100,7 +100,7 @@ export default {
 			if (!value) {
 				return
 			}
-			this.$emit('change-value', value)
+			this.$emit('changeValue', value)
 		},
 	},
 }

--- a/src/components/AppSidebar/TagsItem.vue
+++ b/src/components/AppSidebar/TagsItem.vue
@@ -82,17 +82,17 @@ export default {
 		},
 	},
 	emits: [
-		'add-tag',
-		'set-tags',
+		'addTag',
+		'setTags',
 	],
 	methods: {
 		t,
 
 		addTag(tag) {
-			this.$emit('add-tag', tag)
+			this.$emit('addTag', tag)
 		},
 		setTags(tags) {
-			this.$emit('set-tags', tags)
+			this.$emit('setTags', tags)
 		},
 	},
 }

--- a/src/components/TaskCheckbox.vue
+++ b/src/components/TaskCheckbox.vue
@@ -71,7 +71,7 @@ export default {
 			default: '',
 		},
 	},
-	emits: ['toggle-completed'],
+	emits: ['toggleCompleted'],
 	computed: {
 		ariaLabel() {
 			if (this.cancelled && !this.completed) {
@@ -97,7 +97,7 @@ export default {
 		t,
 
 		toggleCompleted() {
-			this.$emit('toggle-completed')
+			this.$emit('toggleCompleted')
 		},
 	},
 }

--- a/src/components/TaskStatusDisplay.vue
+++ b/src/components/TaskStatusDisplay.vue
@@ -63,8 +63,8 @@ export default {
 		},
 	},
 	emits: [
-		'status-clicked',
-		'reset-status',
+		'statusClicked',
+		'resetStatus',
 	],
 	data() {
 		return {
@@ -86,7 +86,7 @@ export default {
 	},
 	methods: {
 		statusClicked() {
-			this.$emit('status-clicked')
+			this.$emit('statusClicked')
 		},
 		checkTimeout(newStatus) {
 			if (newStatus) {
@@ -96,7 +96,7 @@ export default {
 				if (newStatus.status === 'success') {
 					this.resetStatusTimeout = setTimeout(
 						() => {
-							this.$emit('reset-status')
+							this.$emit('resetStatus')
 						}, 5000,
 					)
 				}

--- a/src/utils/dateStrings.js
+++ b/src/utils/dateStrings.js
@@ -27,7 +27,7 @@ import { convertTimeZone } from './alarms.js'
 /**
  * Returns a formatted string for the due date
  *
- * @param {Task} task The task
+ * @param {import('../models/task.js').Task} task The task
  * @return {string} The formatted due date string
  */
 export function dueDateString(task) {
@@ -88,7 +88,7 @@ export function dueDateString(task) {
 /**
  * Returns a formatted string for the start date
  *
- * @param {Task} task The task
+ * @param {import('../models/task.js').Task} task The task
  * @return {string} The formatted start date string
  */
 export function startDateString(task) {

--- a/src/views/AppSidebar.vue
+++ b/src/views/AppSidebar.vue
@@ -172,7 +172,7 @@ License along with this library. If not, see <http://www.gnu.org/licenses/>.
 					:property-string="completedString"
 					:read-only="readOnly"
 					:task="task"
-					:check-overdue=false
+					:check-overdue="false"
 					@set-value="changeCompletedDate">
 					<template #icon>
 						<CalendarCheck :size="20" />


### PR DESCRIPTION
Fixes all linter warnings:

```
> tasks@0.16.1 lint
> eslint --ext .js,.vue src tests

/nextcloud-app-tasks/src/components/AppNavigation/Colorpicker.vue
  95:15  warning  Custom event name 'color-selected' must be camelCase  vue/custom-event-name-casing

/nextcloud-app-tasks/src/components/AppSidebar/Alarm/AlarmDateTimePickerModal.vue
  75:15  warning  Custom event name 'select-date-time' must be camelCase  vue/custom-event-name-casing

/nextcloud-app-tasks/src/components/AppSidebar/Alarm/AlarmList.vue
  128:15  warning  Custom event name 'add-alarm' must be camelCase     vue/custom-event-name-casing
  138:15  warning  Custom event name 'update-alarm' must be camelCase  vue/custom-event-name-casing
  147:15  warning  Custom event name 'remove-alarm' must be camelCase  vue/custom-event-name-casing

/nextcloud-app-tasks/src/components/AppSidebar/Alarm/AlarmListItem.vue
  213:15  warning  Custom event name 'update-alarm' must be camelCase  vue/custom-event-name-casing
  223:15  warning  Custom event name 'update-alarm' must be camelCase  vue/custom-event-name-casing
  235:15  warning  Custom event name 'remove-alarm' must be camelCase  vue/custom-event-name-casing

/nextcloud-app-tasks/src/components/AppSidebar/Alarm/AlarmListNew.vue
  217:15  warning  Custom event name 'add-alarm' must be camelCase  vue/custom-event-name-casing
  226:15  warning  Custom event name 'add-alarm' must be camelCase  vue/custom-event-name-casing

/nextcloud-app-tasks/src/components/AppSidebar/Alarm/AlarmRelativeTimePickerModal.vue
  152:15  warning  Custom event name 'select-date-time' must be camelCase  vue/custom-event-name-casing

/nextcloud-app-tasks/src/components/AppSidebar/CalendarPickerItem.vue
  111:15  warning  Custom event name 'change-calendar' must be camelCase  vue/custom-event-name-casing

/nextcloud-app-tasks/src/components/AppSidebar/CheckboxItem.vue
  31:18  warning  Custom event name 'set-checked' must be camelCase  vue/custom-event-name-casing

/nextcloud-app-tasks/src/components/AppSidebar/DateTimePickerItem.vue
  124:4  warning  Missing trailing comma  comma-dangle

/nextcloud-app-tasks/src/components/AppSidebar/MultiselectItem.vue
  103:15  warning  Custom event name 'change-value' must be camelCase  vue/custom-event-name-casing

/nextcloud-app-tasks/src/components/AppSidebar/TagsItem.vue
  92:15  warning  Custom event name 'add-tag' must be camelCase   vue/custom-event-name-casing
  95:15  warning  Custom event name 'set-tags' must be camelCase  vue/custom-event-name-casing

/nextcloud-app-tasks/src/components/TaskCheckbox.vue
  100:15  warning  Custom event name 'toggle-completed' must be camelCase  vue/custom-event-name-casing

/nextcloud-app-tasks/src/components/TaskStatusDisplay.vue
  89:15  warning  Custom event name 'status-clicked' must be camelCase  vue/custom-event-name-casing
  99:19  warning  Custom event name 'reset-status' must be camelCase    vue/custom-event-name-casing

/nextcloud-app-tasks/src/utils/dateStrings.js
  30:1  warning  The type 'Task' is undefined  jsdoc/no-undefined-types
  91:1  warning  The type 'Task' is undefined  jsdoc/no-undefined-types

/nextcloud-app-tasks/src/views/AppSidebar.vue
  175:21  warning  Expected to be enclosed by double quotes  vue/html-quotes

✖ 23 problems (0 errors, 23 warnings)
  0 errors and 2 warnings potentially fixable with the `--fix` option.
```