### PR TITLE
fix: remove empty placeholder from translation

### DIFF
--- a/src/components/TaskBody.vue
+++ b/src/components/TaskBody.vue
@@ -91,7 +91,7 @@ License along with this library. If not, see <http://www.gnu.org/licenses/>.
 					:aria-label="t('tasks', '{complete} % completed', {complete: task.complete})"
 					:title="t('tasks', '{complete} % completed', {complete: task.complete})"
 					:color="task.calendar.color" />
-				<Bell v-if="task.alarms.length > 0" :size="20" :title="t('tasks', 'Task has one or more reminders')" />
+				<Bell v-if="task.alarms.length > 0" :size="20" :title="n('tasks', 'Task has one reminder', 'Task has {n} reminders', task.alarms.length, { n: task.alarms.length })" />
 				<NcActions v-if="task.deleteCountdown === null" class="reactive no-nav" menu-align="right">
 					<NcActionButton v-if="!task.calendar.readOnly"
 						:close-after-click="true"

--- a/src/utils/dateStrings.js
+++ b/src/utils/dateStrings.js
@@ -220,10 +220,8 @@ export function formatAlarm(alarm, isAllDay, currentUserTimezone, locale) {
 		// Absolute trigger
 		// There are no timezones in the VALARM component, since dates can only be relative or saved as UTC.
 		const currentUserTimezoneDate = convertTimeZone(alarm.absoluteDate, currentUserTimezone)
-		return t('tasks', '{time}', {
-			time: moment(currentUserTimezoneDate).locale(locale).calendar(null, {
-				sameElse: 'LLL', // Overwrites the default `DD/MM/YYYY` (which misses the time)
-			}),
+		return moment(currentUserTimezoneDate).locale(locale).calendar(null, {
+			sameElse: 'LLL', // Overwrites the default `DD/MM/YYYY` (which misses the time)
 		})
 	}
 }


### PR DESCRIPTION
Closes #2756 and uses the plural translation for the reminder count.