### PR TITLE
fix(style): remove bold font weight from sidebar

### DIFF
--- a/src/components/AppSidebar/CalendarPickerItem.vue
+++ b/src/components/AppSidebar/CalendarPickerItem.vue
@@ -165,7 +165,6 @@ export default {
 				margin: 0;
 				height: var(--default-clickable-area) !important;
 				line-height: var(--default-clickable-area);
-				font-weight: bold;
 			}
 
 			&__actions {

--- a/src/components/AppSidebar/CalendarPickerOption.vue
+++ b/src/components/AppSidebar/CalendarPickerOption.vue
@@ -124,7 +124,6 @@ export default {
 		overflow: hidden;
 		text-overflow: ellipsis;
 		flex-grow: 1;
-		font-weight: bold;
 		white-space: nowrap;
 		color: var(--color-text-lighter);
 		cursor: pointer;

--- a/src/components/AppSidebar/CheckboxItem.vue
+++ b/src/components/AppSidebar/CheckboxItem.vue
@@ -87,7 +87,6 @@ export default {
 		}
 		> span {
 			margin-left: 4px;
-			font-weight: bold;
 			overflow: hidden;
 			text-overflow: ellipsis;
 			white-space: nowrap;

--- a/src/components/AppSidebar/DateTimePickerItem.vue
+++ b/src/components/AppSidebar/DateTimePickerItem.vue
@@ -243,7 +243,6 @@ $blue: #4271a6;
 				}
 
 				&__name {
-					font-weight: bold;
 					flex-grow: 1;
 					padding-right: 14px;
 					overflow: hidden;

--- a/src/components/AppSidebar/MultiselectItem.vue
+++ b/src/components/AppSidebar/MultiselectItem.vue
@@ -180,7 +180,6 @@ export default {
 				margin: 0;
 				height: var(--default-clickable-area) !important;
 				line-height: var(--default-clickable-area);
-				font-weight: bold;
 				position: absolute;
 				width: 100%;
 

--- a/src/components/AppSidebar/MultiselectOption.vue
+++ b/src/components/AppSidebar/MultiselectOption.vue
@@ -84,7 +84,6 @@ export default {
 	}
 
 	&__label {
-		font-weight: bold;
 		padding-right: 14px;
 		overflow: hidden;
 		text-overflow: ellipsis;

--- a/src/components/AppSidebar/SliderItem.vue
+++ b/src/components/AppSidebar/SliderItem.vue
@@ -145,7 +145,6 @@ export default {
 				}
 
 				&__name {
-					font-weight: bold;
 					flex-grow: 1;
 					padding-right: 14px;
 					overflow: hidden;

--- a/src/components/AppSidebar/TagsItem.vue
+++ b/src/components/AppSidebar/TagsItem.vue
@@ -145,7 +145,6 @@ export default {
 				&::placeholder {
 					color: var(--color-text-lighter);
 					opacity: 1;
-					font-weight: bold;
 				}
 			}
 		}

--- a/src/components/AppSidebar/TextItem.vue
+++ b/src/components/AppSidebar/TextItem.vue
@@ -141,7 +141,6 @@ export default {
 				}
 
 				&__name {
-					font-weight: bold;
 					flex-grow: 1;
 					padding-right: 14px;
 					overflow: hidden;


### PR DESCRIPTION
This removes the font weight bold from the sidebar.

Before | After
-|-
![Bildschirmfoto am 2025-01-26 um 22 28 51](https://github.com/user-attachments/assets/b725f84e-cd07-4fd7-9075-98f7f4c86a9b) | ![Bildschirmfoto am 2025-01-26 um 22 28 13](https://github.com/user-attachments/assets/beb7eade-6c0a-4b00-b404-6a070a0923b0)
