### PR TITLE
fix: trash bin with fullday event can be opened again

### DIFF
--- a/src/components/AppNavigation/Trashbin.vue
+++ b/src/components/AppNavigation/Trashbin.vue
@@ -145,6 +145,7 @@ import MenuDown from 'vue-material-design-icons/MenuDown.vue'
 import MenuUp from 'vue-material-design-icons/MenuUp.vue'
 import Undo from 'vue-material-design-icons/Undo.vue'
 
+import { toRaw } from 'vue'
 import { mapGetters } from 'vuex'
 
 export default {
@@ -207,7 +208,7 @@ export default {
 				}
 				let subline = vobject.calendar?.displayName || t('tasks', 'Unknown calendar')
 				if (vobject.isEvent) {
-					const event = vobject?.calendarComponent.getFirstComponent('VEVENT')
+					const event = toRaw(vobject?.calendarComponent.getFirstComponent('VEVENT'))
 					if (event?.startDate.jsDate && event?.isAllDay()) {
 						subline += ' · ' + moment(event.startDate.jsDate).format('LL')
 					} else if (event?.startDate.jsDate) {


### PR DESCRIPTION
Fixes #2609

It seems like the Vue reactivity (Proxy) on `vobject.calendarComponent` causes issues with the ical.js-object.

The reactivity is introduced here (I guess by accident):
https://github.com/nextcloud/tasks/blob/f86b092e0a88f6ae0d85536a69d0eb356013bd42/src/store/calendars.js#L364-L367

So this may also be fixable by avoiding reactivity (Proxy) in `state.deletedCalendarObjects`. 