### PR TITLE
Group tasks with same due date

### DIFF
--- a/src/views/AppContent/task-list.scss
+++ b/src/views/AppContent/task-list.scss
@@ -18,7 +18,7 @@ $breakpoint-mobile: 1024px;
 		position: relative;
 		padding-top: 2px;
 
-		> ol {
+		>ol {
 			filter: drop-shadow(0 0 1px var(--color-box-shadow));
 			z-index: 1;
 
@@ -30,6 +30,12 @@ $breakpoint-mobile: 1024px;
 				margin-top: 12px;
 			}
 		}
+	}
+
+	.grouped-tasks__bucketHeading {
+		font-size: 12px;
+		opacity: 0.7;
+		text-transform: uppercase;
 	}
 
 	.heading {


### PR DESCRIPTION
Here's a draft of something I've wanted for a while:

![image](https://github.com/user-attachments/assets/99b7feb9-3b97-4ae9-81ab-844a9f7f79b6)

Current shortcomings:
- UI freezes when I click one of the tasks (haven't figured out a solution yet, but I bet it's related to the way I update calendar objects in the `filteredCalendars` computation)
- This grouping should only apply when due date sorting is active

Is this a feature you'd be willing to add to Tasks?

