### PR TITLE
Use proper trailing button icon for textfields

### DIFF
--- a/src/components/AppNavigation/ListItemCalendar.vue
+++ b/src/components/AppNavigation/ListItemCalendar.vue
@@ -109,7 +109,7 @@ License along with this library. If not, see <http://www.gnu.org/licenses/>.
 					:title="tooltipMessage"
 					type="text"
 					:show-trailing-button="newCalendarName !== ''"
-					trailing-button-icon="arrowRight"
+					trailing-button-icon="arrowEnd"
 					:error="nameError"
 					:label="t('tasks', 'List name')"
 					:placeholder="t('tasks', 'List name')"

--- a/src/components/HeaderBar.vue
+++ b/src/components/HeaderBar.vue
@@ -29,7 +29,7 @@ License along with this library. If not, see <http://www.gnu.org/licenses/>.
 				:placeholder="placeholder"
 				autocomplete="off"
 				class="reactive"
-				trailing-button-icon="arrowRight"
+				trailing-button-icon="arrowEnd"
 				:show-trailing-button="newTaskName !== ''"
 				:trailing-button-label="placeholder"
 				@trailing-button-click="addTask"

--- a/src/components/TaskBody.vue
+++ b/src/components/TaskBody.vue
@@ -158,7 +158,7 @@ License along with this library. If not, see <http://www.gnu.org/licenses/>.
 					:disabled="isAddingTask"
 					autocomplete="off"
 					class="reactive"
-					trailing-button-icon="arrowRight"
+					trailing-button-icon="arrowEnd"
 					:show-trailing-button="newTaskName !== ''"
 					:trailing-button-label="subtasksCreationPlaceholder"
 					@trailing-button-click="addTask"

--- a/src/views/AppNavigation.vue
+++ b/src/views/AppNavigation.vue
@@ -70,7 +70,7 @@ License along with this library. If not, see <http://www.gnu.org/licenses/>.
 							v-model="newCalendarName"
 							type="text"
 							:show-trailing-button="newCalendarName !== ''"
-							trailing-button-icon="arrowRight"
+							trailing-button-icon="arrowEnd"
 							:error="nameError"
 							:label="t('tasks', 'New list')"
 							:placeholder="t('tasks', 'New list')"


### PR DESCRIPTION
Issue #3052 

It might some library change somewhere somewhen, but the trailing button icon "arrowRight" no longer exists and it's now "arrowEnd"