### PR TITLE
Bump max Nextcloud version to 34

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -20,7 +20,7 @@
     <repository>https://github.com/nextcloud/tasks.git</repository>
     <screenshot>https://raw.githubusercontent.com/nextcloud/tasks/master/screenshots/tasks-1.png</screenshot>
     <dependencies>
-		<php min-version="8.1" max-version="8.5" />
+		<php min-version="8.1" max-version="8.6" />
         <nextcloud min-version="31" max-version="34"/>
         <backend>caldav</backend>
     </dependencies>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@
     <screenshot>https://raw.githubusercontent.com/nextcloud/tasks/master/screenshots/tasks-1.png</screenshot>
     <dependencies>
 		<php min-version="8.1" max-version="8.5" />
-        <nextcloud min-version="31" max-version="33"/>
+        <nextcloud min-version="31" max-version="34"/>
         <backend>caldav</backend>
     </dependencies>
     <navigations>


### PR DESCRIPTION
## Summary

One-line bump of `<nextcloud max-version>` from 33 to 34 in
`appinfo/info.xml` so Tasks installs cleanly on Nextcloud 34 (released
2026-06-09). No code changes — the app already works on 34; users have
been working around this with `occ app:enable tasks --force` (issue
[#3171](https://github.com/nextcloud/tasks/issues/3171)).

## Test plan

- [x] Installed this build against Nextcloud 34.0.0.12 via
      `occ app:enable tasks --force` workflow (functionally
      equivalent to the post-bump install path).
- [x] Verified VTODOs sync via CalDAV, list create/delete in UI,
      calendar integration intact.

Closes #3171.