### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Then open the Tasks app from the app menu.
 * [vdirsyncer](https://vdirsyncer.pimutils.org/en/stable/) (Linux and BSD)
 * [planify](https://github.com/alainm23/planify) (Linux)
 * [jtx Board](https://jtx.techbee.at/) [(Android)](https://play.google.com/store/apps/details?id=at.techbee.jtx)
+* [NowThis](https://nowthis.app/) ([iOS & macOS](https://github.com/asecretcompany/nowthis-source))
 
 ## ETag (or: problem with non-existing conflicts)
 


### PR DESCRIPTION
Added NowThis (OSS) to apps that support Nextcloud Tasks natively on iOS



## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
