### PR TITLE
Handle special keys only when IME is not compositing

### DIFF
--- a/src/components/AppSidebar/NotesItem.vue
+++ b/src/components/AppSidebar/NotesItem.vue
@@ -35,7 +35,9 @@ License along with this library. If not, see <http://www.gnu.org/licenses/>.
 				<textarea ref="note__editor"
 					v-model="newValue"
 					:maxlength="100000"
-					@keyup.escape="setEditing(false)"
+					@compositionstart="compositionstart($event)"
+					@compositionend="compositionend($event)"
+					@keydown.escape="escKeyDown($event)"
 					@keydown.enter.ctrl.prevent="setValue()"
 					@change="setValue()" />
 			</div>
@@ -86,6 +88,7 @@ export default {
 			.use(Mitl)
 		return {
 			md,
+			compositing: false,
 		}
 	},
 	watch: {
@@ -128,6 +131,18 @@ export default {
 		},
 		setNotes($event) {
 			this.setEditing(true, $event)
+		},
+		// Inspired by https://gist.github.com/gotraveltoworld/ecbd2ddc6a0d9bcee8baf396d683e1ba
+		compositionstart($event) {
+			this.compositing = true;
+		},
+		compositionend($event) {
+			this.compositing = false;
+		},
+		escKeyDown($event) {
+			if (!this.compositing) {
+				this.setEditing(false);
+			}
 		},
 	},
 }

--- a/src/components/AppSidebar/NotesItem.vue
+++ b/src/components/AppSidebar/NotesItem.vue
@@ -35,9 +35,9 @@ License along with this library. If not, see <http://www.gnu.org/licenses/>.
 				<textarea ref="note__editor"
 					v-model="newValue"
 					:maxlength="100000"
-					@compositionstart="compositionstart($event)"
-					@compositionend="compositionend($event)"
-					@keydown.escape="escKeyDown($event)"
+					@compositionstart="compositionstart()"
+					@compositionend="compositionend()"
+					@keydown.escape="escKeyDown()"
 					@keydown.enter.ctrl.prevent="setValue()"
 					@change="setValue()" />
 			</div>
@@ -133,15 +133,15 @@ export default {
 			this.setEditing(true, $event)
 		},
 		// Inspired by https://gist.github.com/gotraveltoworld/ecbd2ddc6a0d9bcee8baf396d683e1ba
-		compositionstart($event) {
-			this.compositing = true;
+		compositionstart() {
+			this.compositing = true
 		},
-		compositionend($event) {
-			this.compositing = false;
+		compositionend() {
+			this.compositing = false
 		},
-		escKeyDown($event) {
+		escKeyDown() {
 			if (!this.compositing) {
-				this.setEditing(false);
+				this.setEditing(false)
 			}
 		},
 	},

--- a/src/components/HeaderBar.vue
+++ b/src/components/HeaderBar.vue
@@ -33,8 +33,8 @@ License along with this library. If not, see <http://www.gnu.org/licenses/>.
 				:show-trailing-button="newTaskName !== ''"
 				:trailing-button-label="placeholder"
 				@trailing-button-click="addTask"
-				@compositionstart="compositionstart($event)"
-				@compositionend="compositionend($event)"
+				@compositionstart="compositionstart()"
+				@compositionend="compositionend()"
 				@keydown.esc="clearNewTask($event)"
 				@keydown.enter="addTask"
 				@paste.stop="addMultipleTasks">
@@ -115,16 +115,16 @@ export default {
 			'createTask',
 		]),
 
-		compositionstart($event) {
-			this.compositing = true;
+		compositionstart() {
+			this.compositing = true
 		},
-		compositionend($event) {
-			this.compositing = false;
+		compositionend() {
+			this.compositing = false
 		},
 
 		clearNewTask(event) {
 			if (this.compositing) {
-				return;
+				return
 			}
 
 			event.target.blur()
@@ -133,7 +133,7 @@ export default {
 
 		async addTask() {
 			if (this.compositing) {
-				return;
+				return
 			}
 
 			const data = {

--- a/src/components/HeaderBar.vue
+++ b/src/components/HeaderBar.vue
@@ -33,8 +33,10 @@ License along with this library. If not, see <http://www.gnu.org/licenses/>.
 				:show-trailing-button="newTaskName !== ''"
 				:trailing-button-label="placeholder"
 				@trailing-button-click="addTask"
-				@keyup.esc="clearNewTask($event)"
-				@keyup.enter="addTask"
+				@compositionstart="compositionstart($event)"
+				@compositionend="compositionend($event)"
+				@keydown.esc="clearNewTask($event)"
+				@keydown.enter="addTask"
 				@paste.stop="addMultipleTasks">
 				<template #icon>
 					<Plus :size="20" />
@@ -83,6 +85,7 @@ export default {
 			showCreateMultipleTasksModal: false,
 			multipleTasks: { numberOfTasks: 0, tasks: {} },
 			additionalTaskProperties: {},
+			compositing: false,
 		}
 	},
 	computed: {
@@ -112,12 +115,27 @@ export default {
 			'createTask',
 		]),
 
+		compositionstart($event) {
+			this.compositing = true;
+		},
+		compositionend($event) {
+			this.compositing = false;
+		},
+
 		clearNewTask(event) {
+			if (this.compositing) {
+				return;
+			}
+
 			event.target.blur()
 			this.newTaskName = ''
 		},
 
 		async addTask() {
+			if (this.compositing) {
+				return;
+			}
+
 			const data = {
 				summary: this.newTaskName,
 				// If the task is created in the calendar view,


### PR DESCRIPTION
This fixes interference between special keys (ESC, Enter, ...) for Chinese input methods and the UI.

Closes https://github.com/nextcloud/tasks/issues/2572

---

I drafted this change long time ago (in 2024, roughly before submitting https://github.com/nextcloud/tasks/issues/2572). I don't remember exact reasons to change keyup to keydown. I just remember keyup doesn't work with compositing detection.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
