### PR TITLE
fix(TaskBody): show due date instead of start date in task list

### DIFF
--- a/src/components/TaskBody.vue
+++ b/src/components/TaskBody.vue
@@ -82,7 +82,7 @@ License along with this library. If not, see <http://www.gnu.org/licenses/>.
 					:title="t('tasks', 'Task has a note')"
 					@click="openAppSidebarTab($event, 'app-sidebar-tab-notes')"
 					@dblclick.stop="openAppSidebarTab($event, 'app-sidebar-tab-notes', true)" />
-				<div v-if="task.start || task.due || task.completed" :class="{'date--overdue': overdue(task.startMoment || task.dueMoment) && !task.completed}" class="date">
+				<div v-if="task.due || task.completed" :class="{'date--overdue': overdue(task.dueMoment) && !task.completed}" class="date">
 					<span class="date__short" :class="{ 'date__short--completed': task.completed }">{{ dueDateShort }}</span>
 					<span class="date__long" :class="{ 'date__long--date-only': task.allDay && !task.completed, 'date__long--completed': task.completed }">{{ dueDateLong }}</span>
 				</div>
@@ -289,10 +289,9 @@ export default {
 		}),
 
 		dueDateShort() {
-			const taskDate = this.task.startMoment.isValid() ? this.task.startMoment : this.task.dueMoment
 			if (!this.task.completed) {
-				return taskDate.isValid()
-					? taskDate.calendar(null, {
+				return this.task.dueMoment.isValid()
+					? this.task.dueMoment.calendar(null, {
 						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. Please translate the string and keep the brackets.
 						lastDay: t('tasks', '[Yesterday]'),
 						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. Please translate the string and keep the brackets.
@@ -328,10 +327,9 @@ export default {
 			if (this.task.allDay) {
 				return this.dueDateShort
 			}
-			const taskDate = this.task.startMoment.isValid() ? this.task.startMoment : this.task.dueMoment
 			if (!this.task.completed) {
-				return taskDate.isValid()
-					? taskDate.calendar(null, {
+				return this.task.dueMoment.isValid()
+					? this.task.dueMoment.calendar(null, {
 						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. Please translate the string and keep the brackets.
 						lastDay: t('tasks', '[Yesterday at] LT'),
 						// TRANSLATORS This is a string for moment.js. The square brackets escape the string from moment.js. Please translate the string and keep the brackets.


### PR DESCRIPTION
## Fix: task list shows due date instead of start date (#3187)

### Problem

Since the recurring-tasks change (#3021), the task list started showing the **start date** instead of the **due date** for tasks that have both set — a regression from 0.17.1 (#3187).

### Background

I tried to remember the reasoning behind the original change. As best I can reconstruct it, the idea was to surface *some* date for tasks that have only a start date (which previously showed nothing) — but the precedence ended up backwards, so the start date was preferred in **all** cases, hiding the due date whenever both were set.

Thinking it through again: the start date isn't the actionable date in the list, and recurrence doesn't change that — the due date is what matters, and it's also the value the recurrence completion advances (`task.due || task.start`). Putting a start date in the same unlabeled column as due dates was also the source of the "which date is this?" confusion.

### Fix

Revert the date column to its pre-0.18.0 behavior: **always show the due date.**

- `v-if="task.due || task.completed"`
- overdue highlight based on the due date only
- `dueDateShort` / `dueDateLong` use the due date directly

The recurring indicator icon is unaffected. Start-only tasks show no date text (the long-standing behavior) and still get the existing `CalendarClock` icon hint.

### Testing

- Verified the three date combinations (start+due → due, due-only → due, start-only → no date) on a running instance.
- `npm run lint`, `npm run dev`, and the unit test suite (`vitest`) all pass.

Fixes #3187
