### PR TITLE
Task notes - fix opening URLs in new window

### DIFF
--- a/src/components/AppSidebar/NotesItem.vue
+++ b/src/components/AppSidebar/NotesItem.vue
@@ -82,7 +82,7 @@ export default {
 			.use(Mila, {
 				attrs: {
 					target: '_blank',
-					rel: 'nofollow',
+					rel: 'nofollow noopener noreferrer',
 				},
 			})
 			.use(Mitl)
@@ -104,7 +104,7 @@ export default {
 						this.$refs.note__viewer.textContent = val.slice(0, MAX_NOTE_RENDER_SIZE)
 						return
 					}
-					this.$refs.note__viewer.innerHTML = DOMPurify.sanitize(this.md.render(val))
+					this.$refs.note__viewer.innerHTML = DOMPurify.sanitize(this.md.render(val), { ADD_ATTR: ['target'] })
 				})
 			},
 		},


### PR DESCRIPTION
Add the `target="_blank"` back to the `<a>` that is stripped out by `DOMPurify`. Set `rel="nofollow noopener noreferrer"` to harden against reverse tabnabbing.

I just saw the DCO real name requirement after opening the PR, if this isn't considered trivial feel free to close and have a maintainer recommit.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly ~~or fully~~ generated using AI.

I used Claude Opus 4.8 (chat, not Claude Code) to help me find why the `target` was being stripped out, and it suggested the additional `rel` hardening.
